### PR TITLE
Fix for #9 (missing <th>)

### DIFF
--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -166,7 +166,7 @@ class DynamicDataTable extends Component {
 
         if (!props.renderCheckboxes || !this.props.actions.length) {
             return (
-                <th> </th>
+                <th/>
             );
         }
 

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -165,7 +165,9 @@ class DynamicDataTable extends Component {
         const state = this.state;
 
         if (!props.renderCheckboxes || !this.props.actions.length) {
-            return;
+            return (
+                <th> </th>
+            );
         }
 
         return (


### PR DESCRIPTION
This PR fixes a missing `<th>` when missing the `renderCheckboxes` or `actions` props.