### PR TITLE
AJAX Dynamic Data Table component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 .idea
+*.tgz

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -52,9 +52,9 @@ class AjaxDynamicDataTable extends Component {
 
     axios.get(this.props.apiUrl, {
       params: {
-        page: page,
-        orderByField: orderByField,
-        orderByDirection: orderByDirection
+        page,
+        orderByField,
+        orderByDirection
       }
     }).then(response => {
       const {
@@ -63,7 +63,7 @@ class AjaxDynamicDataTable extends Component {
       } = response.data.data;
       const rows = response.data.data.data;
       this.setState({
-        rows: rows,
+        rows,
         currentPage: current_page,
         totalPages: last_page
       });
@@ -88,5 +88,4 @@ class AjaxDynamicDataTable extends Component {
 AjaxDynamicDataTable.propTypes = {
   apiUrl: PropTypes.string
 };
-AjaxDynamicDataTable.defaultProps = {};
 export default AjaxDynamicDataTable;

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -39,9 +39,11 @@ class AjaxDynamicDataTable extends Component {
     const axios = require('axios');
 
     axios.get(this.props.apiUrl, {
-      page: page,
-      orderByField: state.orderByField,
-      orderByDirection: state.orderByDirection
+      params: {
+        page: page,
+        orderByField: state.orderByField,
+        orderByDirection: state.orderByDirection
+      }
     }).then(response => {
       const data = response.data.data;
       const rows = data.data;
@@ -71,7 +73,5 @@ class AjaxDynamicDataTable extends Component {
 AjaxDynamicDataTable.propTypes = {
   apiUrl: PropTypes.string
 };
-AjaxDynamicDataTable.defaultProps = {
-  apiUrl: null
-};
+AjaxDynamicDataTable.defaultProps = {};
 export default AjaxDynamicDataTable;

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -1,5 +1,9 @@
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
+import { AxiosInstance as axios } from "axios";
 
 class AjaxDynamicDataTable extends Component {
   constructor(props) {
@@ -19,7 +23,7 @@ class AjaxDynamicDataTable extends Component {
 
   render() {
     const state = this.state;
-    return React.createElement(DynamicDataTable, {
+    return React.createElement(DynamicDataTable, _extends({
       rows: state.rows,
       currentPage: state.currentPage,
       totalPages: state.totalPages,
@@ -27,21 +31,25 @@ class AjaxDynamicDataTable extends Component {
       orderByDirection: state.orderByDirection,
       changePage: page => this.changePage(page),
       changeOrder: (field, direction) => this.changeOrder(field, direction)
-    });
+    }, this.props));
   }
 
   loadPage(page) {
-    axois.get(this.props.apiUrl, {
+    const state = this.state;
+
+    const axios = require('axios');
+
+    axios.get(this.props.apiUrl, {
       page: page,
-      orderByField: this.state.api.orderByField,
-      orderByDirection: this.state.api.orderByDirection
+      orderByField: state.orderByField,
+      orderByDirection: state.orderByDirection
     }).then(response => {
       const data = response.data.data;
-      const meta = response.data.meta;
+      const rows = data.data;
       this.setState({
-        rows: data,
-        currentPage: meta.current_page,
-        totalPages: meta.last_page
+        rows: rows,
+        currentPage: data.current_page,
+        totalPages: data.last_page
       });
     });
   }
@@ -62,7 +70,7 @@ class AjaxDynamicDataTable extends Component {
 }
 
 DynamicDataTable.propTypes = {
-  apiUrl: PropTypes.apiUrl
+  apiUrl: PropTypes.string
 };
 DynamicDataTable.defaultProps = {
   apiUrl: null

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react';
+import DynamicDataTable from "./DynamicDataTable";
+
+class AjaxDynamicDataTable extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      rows: [],
+      currentPage: 1,
+      totalPages: 1,
+      orderByField: null,
+      orderByDirection: null
+    };
+  }
+
+  componentDidMount() {
+    this.loadPage();
+  }
+
+  render() {
+    const state = this.state;
+    return React.createElement(DynamicDataTable, {
+      rows: state.rows,
+      currentPage: state.currentPage,
+      totalPages: state.totalPages,
+      orderByField: state.orderByField,
+      orderByDirection: state.orderByDirection,
+      changePage: page => this.changePage(page),
+      changeOrder: (field, direction) => this.changeOrder(field, direction)
+    });
+  }
+
+  loadPage(page) {
+    axois.get(this.props.apiUrl, {
+      page: page,
+      orderByField: this.state.api.orderByField,
+      orderByDirection: this.state.api.orderByDirection
+    }).then(response => {
+      const data = response.data.data;
+      const meta = response.data.meta;
+      this.setState({
+        rows: data,
+        currentPage: meta.current_page,
+        totalPages: meta.last_page
+      });
+    });
+  }
+
+  changePage(page) {
+    this.loadPage(page);
+  }
+
+  changeOrder(field, direction) {
+    this.setState({
+      orderByField: field,
+      orderByDirection: direction
+    }, () => {
+      this.loadPage(this.state.changePage);
+    });
+  }
+
+}
+
+DynamicDataTable.propTypes = {
+  apiUrl: PropTypes.apiUrl
+};
+DynamicDataTable.defaultProps = {
+  apiUrl: null
+};
+export default AjaxDynamicDataTable;

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -14,7 +14,7 @@ class AjaxDynamicDataTable extends Component {
   }
 
   componentDidMount() {
-    this.loadPage();
+    this.loadPage(1);
   }
 
   render() {

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -3,7 +3,6 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
-import { AxiosInstance as axios } from "axios";
 
 class AjaxDynamicDataTable extends Component {
   constructor(props) {
@@ -69,10 +68,10 @@ class AjaxDynamicDataTable extends Component {
 
 }
 
-DynamicDataTable.propTypes = {
+AjaxDynamicDataTable.propTypes = {
   apiUrl: PropTypes.string
 };
-DynamicDataTable.defaultProps = {
+AjaxDynamicDataTable.defaultProps = {
   apiUrl: null
 };
 export default AjaxDynamicDataTable;

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -22,36 +22,48 @@ class AjaxDynamicDataTable extends Component {
   }
 
   render() {
-    const state = this.state;
+    const {
+      rows,
+      currentPage,
+      totalPages,
+      orderByField,
+      orderByDirection
+    } = this.state;
     return React.createElement(DynamicDataTable, _extends({
-      rows: state.rows,
-      currentPage: state.currentPage,
-      totalPages: state.totalPages,
-      orderByField: state.orderByField,
-      orderByDirection: state.orderByDirection,
-      changePage: page => this.changePage(page),
-      changeOrder: (field, direction) => this.changeOrder(field, direction)
+      rows: rows,
+      currentPage: currentPage,
+      totalPages: totalPages,
+      orderByField: orderByField,
+      orderByDirection: orderByDirection,
+      changePage: this.changePage.bind(this),
+      changeOrder: this.changeOrder.bind(this)
     }, this.props));
   }
 
   loadPage(page) {
-    const state = this.state;
+    const {
+      orderByField,
+      orderByDirection
+    } = this.state;
 
     const axios = require('axios');
 
     axios.get(this.props.apiUrl, {
       params: {
         page: page,
-        orderByField: state.orderByField,
-        orderByDirection: state.orderByDirection
+        orderByField: orderByField,
+        orderByDirection: orderByDirection
       }
     }).then(response => {
-      const data = response.data.data;
-      const rows = data.data;
+      const {
+        current_page,
+        last_page
+      } = response.data.data;
+      const rows = response.data.data.data;
       this.setState({
         rows: rows,
-        currentPage: data.current_page,
-        totalPages: data.last_page
+        currentPage: current_page,
+        totalPages: last_page
       });
     });
   }

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -6,8 +6,8 @@ import DynamicDataTable from "./DynamicDataTable";
 import { AxiosInstance as axios } from "axios";
 
 class AjaxDynamicDataTable extends Component {
-  constructor(props) {
-    super(props);
+  constructor() {
+    super();
     this.state = {
       rows: [],
       currentPage: 1,
@@ -15,6 +15,8 @@ class AjaxDynamicDataTable extends Component {
       orderByField: null,
       orderByDirection: null
     };
+    this.changePage = this.changePage.bind(this);
+    this.changeOrder = this.changeOrder.bind(this);
   }
 
   componentDidMount() {
@@ -35,8 +37,8 @@ class AjaxDynamicDataTable extends Component {
       totalPages: totalPages,
       orderByField: orderByField,
       orderByDirection: orderByDirection,
-      changePage: this.changePage.bind(this),
-      changeOrder: this.changeOrder.bind(this)
+      changePage: this.changePage,
+      changeOrder: this.changeOrder
     }, this.props));
   }
 

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -3,6 +3,7 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
+import { AxiosInstance as axios } from "axios";
 
 class AjaxDynamicDataTable extends Component {
   constructor(props) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "@babel/cli": "^7.1.0",
     "@babel/core": "^7.1.0",
     "@babel/preset-react": "^7.0.0"
+  },
+  "dependencies": {
+    "axios": "^0.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -82,7 +82,6 @@ AjaxDynamicDataTable.propTypes = {
 };
 
 AjaxDynamicDataTable.defaultProps = {
-    apiUrl: null,
 };
 
 export default AjaxDynamicDataTable;

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
-import {AxiosInstance as axios} from "axios";
 
 class AjaxDynamicDataTable extends Component {
 
@@ -78,11 +77,11 @@ class AjaxDynamicDataTable extends Component {
 
 }
 
-DynamicDataTable.propTypes = {
+AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
 };
 
-DynamicDataTable.defaultProps = {
+AjaxDynamicDataTable.defaultProps = {
     apiUrl: null,
 };
 

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
+import {AxiosInstance as axios} from "axios";
 
 class AjaxDynamicDataTable extends Component {
 
@@ -32,25 +34,31 @@ class AjaxDynamicDataTable extends Component {
                 orderByDirection={state.orderByDirection}
                 changePage={page => this.changePage(page)}
                 changeOrder={(field, direction) => this.changeOrder(field, direction)}
+                {...this.props}
             />
         );
     }
 
     loadPage(page) {
-        axois.get(this.props.apiUrl, {
+
+        const state = this.state;
+        const axios = require('axios');
+
+        axios.get(this.props.apiUrl, {
 
             page: page,
-            orderByField: this.state.api.orderByField,
-            orderByDirection: this.state.api.orderByDirection,
+            orderByField: state.orderByField,
+            orderByDirection: state.orderByDirection,
 
         }).then((response) => {
 
             const data = response.data.data;
-            const meta = response.data.meta;
+            const rows = data.data;
+
             this.setState({
-                rows: data,
-                currentPage: meta.current_page,
-                totalPages: meta.last_page,
+                rows: rows,
+                currentPage: data.current_page,
+                totalPages: data.last_page,
             });
 
         });
@@ -71,7 +79,7 @@ class AjaxDynamicDataTable extends Component {
 }
 
 DynamicDataTable.propTypes = {
-    apiUrl: PropTypes.apiUrl,
+    apiUrl: PropTypes.string,
 };
 
 DynamicDataTable.defaultProps = {

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -5,8 +5,8 @@ import {AxiosInstance as axios} from "axios";
 
 class AjaxDynamicDataTable extends Component {
 
-    constructor(props) {
-        super(props);
+    constructor() {
+        super();
 
         this.state = {
             rows: [],
@@ -15,6 +15,9 @@ class AjaxDynamicDataTable extends Component {
             orderByField: null,
             orderByDirection: null,
         };
+
+        this.changePage = this.changePage.bind(this);
+        this.changeOrder = this.changeOrder.bind(this);
     }
 
     componentDidMount() {
@@ -32,8 +35,8 @@ class AjaxDynamicDataTable extends Component {
                 totalPages={totalPages}
                 orderByField={orderByField}
                 orderByDirection={orderByDirection}
-                changePage={this.changePage.bind(this)}
-                changeOrder={this.changeOrder.bind(this)}
+                changePage={this.changePage}
+                changeOrder={this.changeOrder}
                 {...this.props}
             />
         );

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
+import {AxiosInstance as axios} from "axios";
 
 class AjaxDynamicDataTable extends Component {
 
@@ -44,11 +45,13 @@ class AjaxDynamicDataTable extends Component {
         const axios = require('axios');
 
         axios.get(this.props.apiUrl, {
+
             params: {
                 page: page,
                 orderByField: state.orderByField,
                 orderByDirection: state.orderByDirection,
-            },
+            }
+
         }).then((response) => {
 
             const data = response.data.data;

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -16,7 +16,7 @@ class AjaxDynamicDataTable extends Component {
     }
 
     componentDidMount() {
-        this.loadPage();
+        this.loadPage(1);
     }
 
     render() {

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -44,11 +44,11 @@ class AjaxDynamicDataTable extends Component {
         const axios = require('axios');
 
         axios.get(this.props.apiUrl, {
-
-            page: page,
-            orderByField: state.orderByField,
-            orderByDirection: state.orderByDirection,
-
+            params: {
+                page: page,
+                orderByField: state.orderByField,
+                orderByDirection: state.orderByDirection,
+            },
         }).then((response) => {
 
             const data = response.data.data;

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -49,22 +49,14 @@ class AjaxDynamicDataTable extends Component {
 
         axios.get(this.props.apiUrl, {
 
-            params: {
-                page: page,
-                orderByField: orderByField,
-                orderByDirection: orderByDirection,
-            }
+            params: { page, orderByField, orderByDirection }
 
         }).then((response) => {
 
             const {current_page, last_page} = response.data.data;
             const rows = response.data.data.data;
 
-            this.setState({
-                rows: rows,
-                currentPage: current_page,
-                totalPages: last_page,
-            });
+            this.setState({ rows, currentPage: current_page, totalPages: last_page });
 
         });
     }
@@ -85,9 +77,6 @@ class AjaxDynamicDataTable extends Component {
 
 AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
-};
-
-AjaxDynamicDataTable.defaultProps = {
 };
 
 export default AjaxDynamicDataTable;

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import DynamicDataTable from "./DynamicDataTable";
+
+class AjaxDynamicDataTable extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            rows: [],
+            currentPage: 1,
+            totalPages: 1,
+            orderByField: null,
+            orderByDirection: null,
+        };
+    }
+
+    componentDidMount() {
+        this.loadPage();
+    }
+
+    render() {
+
+        const state = this.state;
+
+        return (
+            <DynamicDataTable
+                rows={state.rows}
+                currentPage={state.currentPage}
+                totalPages={state.totalPages}
+                orderByField={state.orderByField}
+                orderByDirection={state.orderByDirection}
+                changePage={page => this.changePage(page)}
+                changeOrder={(field, direction) => this.changeOrder(field, direction)}
+            />
+        );
+    }
+
+    loadPage(page) {
+        axois.get(this.props.apiUrl, {
+
+            page: page,
+            orderByField: this.state.api.orderByField,
+            orderByDirection: this.state.api.orderByDirection,
+
+        }).then((response) => {
+
+            const data = response.data.data;
+            const meta = response.data.meta;
+            this.setState({
+                rows: data,
+                currentPage: meta.current_page,
+                totalPages: meta.last_page,
+            });
+
+        });
+    }
+
+    changePage(page) {
+        this.loadPage(page)
+    }
+
+    changeOrder(field, direction) {
+        this.setState({ orderByField: field, orderByDirection: direction }, () => {
+
+            this.loadPage(this.state.changePage);
+
+        });
+    }
+
+}
+
+DynamicDataTable.propTypes = {
+    apiUrl: PropTypes.apiUrl,
+};
+
+DynamicDataTable.defaultProps = {
+    apiUrl: null,
+};
+
+export default AjaxDynamicDataTable;

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -23,17 +23,17 @@ class AjaxDynamicDataTable extends Component {
 
     render() {
 
-        const state = this.state;
+        const {rows, currentPage, totalPages, orderByField, orderByDirection} = this.state;
 
         return (
             <DynamicDataTable
-                rows={state.rows}
-                currentPage={state.currentPage}
-                totalPages={state.totalPages}
-                orderByField={state.orderByField}
-                orderByDirection={state.orderByDirection}
-                changePage={page => this.changePage(page)}
-                changeOrder={(field, direction) => this.changeOrder(field, direction)}
+                rows={rows}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                orderByField={orderByField}
+                orderByDirection={orderByDirection}
+                changePage={this.changePage.bind(this)}
+                changeOrder={this.changeOrder.bind(this)}
                 {...this.props}
             />
         );
@@ -41,26 +41,26 @@ class AjaxDynamicDataTable extends Component {
 
     loadPage(page) {
 
-        const state = this.state;
+        const {orderByField, orderByDirection} = this.state;
         const axios = require('axios');
 
         axios.get(this.props.apiUrl, {
 
             params: {
                 page: page,
-                orderByField: state.orderByField,
-                orderByDirection: state.orderByDirection,
+                orderByField: orderByField,
+                orderByDirection: orderByDirection,
             }
 
         }).then((response) => {
 
-            const data = response.data.data;
-            const rows = data.data;
+            const {current_page, last_page} = response.data.data;
+            const rows = response.data.data.data;
 
             this.setState({
                 rows: rows,
-                currentPage: data.current_page,
-                totalPages: data.last_page,
+                currentPage: current_page,
+                totalPages: last_page,
             });
 
         });


### PR DESCRIPTION
This PR provides an AJAX Dynamic Data Table component that allows for rapid integration using the [Laravel API for React Dynamic Data Table](https://github.com/langleyfoxall/react-dynamic-data-table-laravel-api) package, as follows.

```jsx
<AjaxDynamicDataTable apiUrl={'http://example.test/web-api/users'}/>
```

This initial version can be built upon as needed.

This PR relates to issue #7.