### PR TITLE
Add clickable rows

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -3,7 +3,6 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
-import { AxiosInstance as axios } from "axios";
 
 class AjaxDynamicDataTable extends Component {
   constructor() {

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -2,10 +2,20 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class DataRow extends Component {
+  handleOnClick(row) {
+    if (!!onClick) {
+      return onClick(row);
+    }
+  }
+
   render() {
-    const props = this.props;
-    const row = props.row;
-    return React.createElement("tr", null, this.renderCheckboxCell(row.id), props.fields.map(field => this.renderCell(field, row)), this.renderButtons(row));
+    const {
+      row,
+      fields
+    } = this.props;
+    return React.createElement("tr", {
+      onClick: () => handleOnClick(row)
+    }, this.renderCheckboxCell(row.id), fields.map(field => this.renderCell(field, row)), this.renderButtons(row));
   }
 
   renderCheckboxCell(value) {
@@ -106,6 +116,7 @@ DataRow.propTypes = {
   checkboxIsChecked: PropTypes.func,
   checkboxChange: PropTypes.func,
   dataItemManipulator: PropTypes.func,
-  renderCheckboxes: PropTypes.bool
+  renderCheckboxes: PropTypes.bool,
+  onClick: PropTypes.func
 };
 export default DataRow;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import DataRow from "./Components/DataRow";
 import Pagination from "./Components/Pagination";
 
@@ -9,6 +10,7 @@ class DynamicDataTable extends Component {
     this.state = {
       checkedRowIds: []
     };
+    this.className = this.className.bind(this);
   }
 
   componentWillUpdate(nextProps) {
@@ -17,6 +19,15 @@ class DynamicDataTable extends Component {
         checkedRowIds: []
       });
     }
+  }
+
+  className() {
+    const {
+      onClick
+    } = this.props;
+    return classNames(['table', 'table-striped', {
+      'table-hover': !!onClick
+    }]);
   }
 
   getFields() {
@@ -103,20 +114,27 @@ class DynamicDataTable extends Component {
     return React.createElement("div", null, React.createElement("div", {
       className: "table-responsive"
     }, React.createElement("table", {
-      className: "table table-striped"
+      className: this.classNames()
     }, React.createElement("thead", null, React.createElement("tr", null, this.renderCheckboxCell('all'), fields.map(field => this.renderHeader(field)), this.renderActionsCell())), React.createElement("tbody", null, rows.map(row => this.renderRow(row))))), this.renderPagination());
   }
 
   renderRow(row) {
+    const {
+      onClick,
+      buttons,
+      renderCheckBoxes,
+      dataItemManipulator
+    } = this.props;
     return React.createElement(DataRow, {
       key: row.id,
       row: row,
-      buttons: this.props.buttons,
+      onClick: onClick,
+      buttons: buttons,
       fields: this.getFields(),
       checkboxIsChecked: value => this.checkboxIsChecked(value),
       checkboxChange: e => this.checkboxChange(e),
-      dataItemManipulator: (field, value) => this.props.dataItemManipulator(field, value),
-      renderCheckboxes: this.props.renderCheckboxes
+      dataItemManipulator: (field, value) => dataItemManipulator(field, value),
+      renderCheckboxes: renderCheckBoxes
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-react": "^7.0.0"
   },
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.18.0",
+    "classnames": "^2.2.6"
   }
 }

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DynamicDataTable from "./DynamicDataTable";
-import {AxiosInstance as axios} from "axios";
 
 class AjaxDynamicDataTable extends Component {
 

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -3,14 +3,19 @@ import PropTypes from 'prop-types';
 
 class DataRow extends Component {
 
+    handleOnClick(row) {
+        if (!!onClick) {
+            return onClick(row);
+        }
+    }
+
     render() {
-        const props = this.props;
-        const row = props.row;
+        const { row, fields } = this.props;
 
         return (
-            <tr>
+            <tr onClick={() => handleOnClick(row)}>
                 { this.renderCheckboxCell(row.id) }
-                { props.fields.map(field => this.renderCell(field, row)) }
+                { fields.map(field => this.renderCell(field, row)) }
                 { this.renderButtons(row) }
             </tr>
         );
@@ -119,7 +124,8 @@ DataRow.propTypes = {
     checkboxIsChecked: PropTypes.func,
     checkboxChange: PropTypes.func,
     dataItemManipulator: PropTypes.func,
-    renderCheckboxes: PropTypes.bool
+    renderCheckboxes: PropTypes.bool,
+    onClick: PropTypes.func
 };
 
 export default DataRow;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
 import DataRow from "./Components/DataRow";
 import Pagination from "./Components/Pagination";
 
@@ -10,6 +12,8 @@ class DynamicDataTable extends Component {
         this.state = {
             checkedRowIds: [],
         };
+
+        this.className = this.className.bind(this);
     }
 
     componentWillUpdate(nextProps) {
@@ -18,6 +22,15 @@ class DynamicDataTable extends Component {
                 checkedRowIds: [],
             });
         }
+    }
+
+    className() {
+        const { onClick } = this.props;
+
+        return classNames([
+            'table', 'table-striped',
+            { 'table-hover': !!onClick }
+        ]);
     }
 
     getFields() {
@@ -110,7 +123,7 @@ class DynamicDataTable extends Component {
         return (
             <div>
                 <div className="table-responsive">
-                    <table className="table table-striped">
+                    <table className={this.classNames()}>
                         <thead>
                             <tr>
                                 { this.renderCheckboxCell('all') }
@@ -129,16 +142,19 @@ class DynamicDataTable extends Component {
     }
 
     renderRow(row) {
+        const { onClick, buttons, renderCheckBoxes, dataItemManipulator } = this.props;
+
         return (
             <DataRow
                 key={row.id}
                 row={row}
-                buttons={this.props.buttons}
+                onClick={onClick}
+                buttons={buttons}
                 fields={this.getFields()}
                 checkboxIsChecked={(value) => this.checkboxIsChecked(value)}
                 checkboxChange={(e) => this.checkboxChange(e)}
-                dataItemManipulator={(field, value) => this.props.dataItemManipulator(field, value)}
-                renderCheckboxes={this.props.renderCheckboxes}
+                dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
+                renderCheckboxes={renderCheckBoxes}
             />
         );
     }


### PR DESCRIPTION
While adding this feature I noticed some inconsistencies (some back to back). For example, you use `new RegExp` and then directly under it you use a literal regex. This should probably be standardized.

I've also added `classNames`, a micro package that was suggested by Alex a while ago, it's used to easily adding classes (returning a string) based on an expression.

⚠️ I spent 10 minutes or so trying to test this on a current project by locally pointing to the package using `file:` but it failed to compile due to Babel/Webpack/Laravel Mix. 

I believe the code itself is fine but will need confirming at some point (feel free to test).