### PR TITLE
Add custom row renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,43 +229,26 @@ the row that is clicked. It also adds the bootstrap `table-hover` class onto the
 
 ### Rendering custom rows
 
-If you come across a situation where the auto generated rows are not suitable for your project
-you can use the `rowRenderer` prop to return a `React.isValidElement` (hopefully a TR!). 
-When used the data table will pass back an object with properties that consist of variables
-and functions that could be used to recreate the default row.
+If you come across a situation where the automatically generated rows are not suitable for your project
+you can use the `rowRenderer` prop. This prop expects a callable that receives a single argument, 
+and returns a valid React element, which should be a `<tr>` element.
 
-The default prop value is used for generating the default row:
-```JSX
-static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
-    return (
-        <DataRow
-            key={row.id}
-            row={row}
-            onClick={onClick}
-            buttons={buttons}
-            fields={fields}
-            renderCheckboxes={renderCheckboxes}
-            checkboxIsChecked={checkboxIsChecked}
-            checkboxChange={onCheckboxChange}
-            dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
-        />
-    );
-}
-```
+The argument passed to the `rowRenderer` callable is a JavaScript object that contain the following properties.
 
-The properties are used for the following things:
 ```JS
 {
-  row, // Instance of row
-  onClick, // On click handler
-  buttons, // Array of buttons
-  fields, // Visible fields
-  renderCheckboxes, // Bool for rendering checkboxes
-  checkboxIsChecked, // Check if checkbox is checked
-  onCheckboxChange, // Function to add checkbox to state
-  dataItemManipulator // Handle data manipulation
+  row,                // Instance of data row
+  onClick,            // Row on click handler
+  buttons,            // Array of buttons
+  fields,             // Visible fields
+  renderCheckboxes,   // Boolean indicating whether to render checkboxes
+  checkboxIsChecked,  // Boolean indicating if checkbox is checked
+  onCheckboxChange,   // Callable that is called when a per row checkbox is changed
+  dataItemManipulator // Callable that handles manipulation of every item in the data row
 }
 ```
+
+For implementation details regarding these properties, see the other relevant areas of the documentatio.
 
 ### Bulk select checkboxes
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,46 @@ the row that is clicked. It also adds the bootstrap `table-hover` class onto the
 />
 ```
 
+### Rendering custom rows
+
+If you come across a situation where the auto generated rows are not suitable for your project
+you can use the `rowRenderer` prop to return a `React.isValidElement` (hopefully a TR!). 
+When used the data table will pass back an object with properties that consist of variables
+and functions that could be used to recreate the default row.
+
+The default prop value is used for generating the default row:
+```JSX
+static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
+    return (
+        <DataRow
+            key={row.id}
+            row={row}
+            onClick={onClick}
+            buttons={buttons}
+            fields={fields}
+            renderCheckboxes={renderCheckboxes}
+            checkboxIsChecked={checkboxIsChecked}
+            checkboxChange={onCheckboxChange}
+            dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
+        />
+    );
+}
+```
+
+The properties are used for the following things:
+```JS
+{
+  row, // Instance of row
+  onClick, // On click handler
+  buttons, // Array of buttons
+  fields, // Visible fields
+  renderCheckboxes, // Bool for rendering checkboxes
+  checkboxIsChecked, // Check if checkbox is checked
+  onCheckboxChange, // Function to add checkbox to state
+  dataItemManipulator // Handle data manipulation
+}
+```
+
 ### Bulk select checkboxes
 
 If you wish to allow users to bulk select users in a React Dynamic Data Table,

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -13,6 +13,29 @@ class DynamicDataTable extends Component {
     this.className = this.className.bind(this);
   }
 
+  static rowRenderer({
+    row,
+    onClick,
+    buttons,
+    fields,
+    renderCheckboxes,
+    checkboxIsChecked,
+    onCheckboxChange,
+    dataItemManipulator
+  }) {
+    return React.createElement(DataRow, {
+      key: row.id,
+      row: row,
+      onClick: onClick,
+      buttons: buttons,
+      fields: fields,
+      renderCheckboxes: renderCheckboxes,
+      checkboxIsChecked: checkboxIsChecked,
+      checkboxChange: onCheckboxChange,
+      dataItemManipulator: (field, value) => dataItemManipulator(field, value)
+    });
+  }
+
   componentWillUpdate(nextProps) {
     if (nextProps.rows !== this.props.rows) {
       this.setState({
@@ -335,27 +358,6 @@ class DynamicDataTable extends Component {
 
 }
 
-const rowRenderer = ({
-  row,
-  onClick,
-  buttons,
-  fields,
-  renderCheckboxes,
-  checkboxIsChecked,
-  onCheckboxChange,
-  dataItemManipulator
-}) => React.createElement(DataRow, {
-  key: row.id,
-  row: row,
-  onClick: onClick,
-  buttons: buttons,
-  fields: fields,
-  renderCheckboxes: renderCheckboxes,
-  checkboxIsChecked: checkboxIsChecked,
-  checkboxChange: onCheckboxChange,
-  dataItemManipulator: (field, value) => dataItemManipulator(field, value)
-});
-
 DynamicDataTable.propTypes = {
   rows: PropTypes.array,
   fieldsToExclude: PropTypes.array,
@@ -397,6 +399,6 @@ DynamicDataTable.defaultProps = {
       window.location = `${location.href}/${row.id}`;
     }
   }],
-  rowRenderer: rowRenderer
+  rowRenderer: DynamicDataTable.rowRenderer
 };
 export default DynamicDataTable;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -122,19 +122,20 @@ class DynamicDataTable extends Component {
     const {
       onClick,
       buttons,
-      renderCheckBoxes,
-      dataItemManipulator
+      renderCheckBoxes: renderCheckboxes,
+      dataItemManipulator,
+      rowRenderer
     } = this.props;
-    return React.createElement(DataRow, {
+    return rowRenderer({
+      row,
+      onClick,
+      buttons,
+      renderCheckboxes,
       key: row.id,
-      row: row,
-      onClick: onClick,
-      buttons: buttons,
       fields: this.getFields(),
-      checkboxIsChecked: value => this.checkboxIsChecked(value),
-      checkboxChange: e => this.checkboxChange(e),
       dataItemManipulator: (field, value) => dataItemManipulator(field, value),
-      renderCheckboxes: renderCheckBoxes
+      checkboxIsChecked: value => this.checkboxIsChecked(value),
+      onCheckboxChange: e => this.checkboxChange(e)
     });
   }
 
@@ -334,6 +335,27 @@ class DynamicDataTable extends Component {
 
 }
 
+const rowRenderer = ({
+  row,
+  onClick,
+  buttons,
+  fields,
+  renderCheckboxes,
+  checkboxIsChecked,
+  onCheckboxChange,
+  dataItemManipulator
+}) => React.createElement(DataRow, {
+  key: row.id,
+  row: row,
+  onClick: onClick,
+  buttons: buttons,
+  fields: fields,
+  renderCheckboxes: renderCheckboxes,
+  checkboxIsChecked: checkboxIsChecked,
+  checkboxChange: onCheckboxChange,
+  dataItemManipulator: (field, value) => dataItemManipulator(field, value)
+});
+
 DynamicDataTable.propTypes = {
   rows: PropTypes.array,
   fieldsToExclude: PropTypes.array,
@@ -349,7 +371,8 @@ DynamicDataTable.propTypes = {
   errorMessage: PropTypes.string,
   noDataMessage: PropTypes.string,
   dataItemManipulator: PropTypes.func,
-  buttons: PropTypes.array
+  buttons: PropTypes.array,
+  rowRenderer: PropTypes.func
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -373,6 +396,7 @@ DynamicDataTable.defaultProps = {
     callback: row => {
       window.location = `${location.href}/${row.id}`;
     }
-  }]
+  }],
+  rowRenderer: rowRenderer
 };
 export default DynamicDataTable;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -142,21 +142,19 @@ class DynamicDataTable extends Component {
     }
 
     renderRow(row) {
-        const { onClick, buttons, renderCheckBoxes, dataItemManipulator } = this.props;
+        const { onClick, buttons, renderCheckBoxes: renderCheckboxes, dataItemManipulator, rowRenderer } = this.props;
 
-        return (
-            <DataRow
-                key={row.id}
-                row={row}
-                onClick={onClick}
-                buttons={buttons}
-                fields={this.getFields()}
-                checkboxIsChecked={(value) => this.checkboxIsChecked(value)}
-                checkboxChange={(e) => this.checkboxChange(e)}
-                dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
-                renderCheckboxes={renderCheckBoxes}
-            />
-        );
+        return rowRenderer({
+            row,
+            onClick,
+            buttons,
+            renderCheckboxes,
+            key: row.id,
+            fields: this.getFields(),
+            dataItemManipulator: (field, value) => dataItemManipulator(field, value),
+            checkboxIsChecked: (value) => this.checkboxIsChecked(value),
+            onCheckboxChange: (e) => this.checkboxChange(e),
+        });
     }
 
     renderHeader(field) {
@@ -383,6 +381,20 @@ class DynamicDataTable extends Component {
     }
 }
 
+const rowRenderer = ({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) => (
+    <DataRow
+        key={row.id}
+        row={row}
+        onClick={onClick}
+        buttons={buttons}
+        fields={fields}
+        renderCheckboxes={renderCheckboxes}
+        checkboxIsChecked={checkboxIsChecked}
+        checkboxChange={onCheckboxChange}
+        dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
+    />
+)
+
 DynamicDataTable.propTypes = {
     rows: PropTypes.array,
     fieldsToExclude: PropTypes.array,
@@ -399,6 +411,7 @@ DynamicDataTable.propTypes = {
     noDataMessage: PropTypes.string,
     dataItemManipulator: PropTypes.func,
     buttons: PropTypes.array,
+    rowRenderer: PropTypes.func,
 };
 
 DynamicDataTable.defaultProps = {
@@ -424,6 +437,7 @@ DynamicDataTable.defaultProps = {
             }
         },
     ],
+    rowRenderer: rowRenderer,
 };
 
 export default DynamicDataTable;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -16,6 +16,22 @@ class DynamicDataTable extends Component {
         this.className = this.className.bind(this);
     }
 
+    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
+        return (
+            <DataRow
+                key={row.id}
+                row={row}
+                onClick={onClick}
+                buttons={buttons}
+                fields={fields}
+                renderCheckboxes={renderCheckboxes}
+                checkboxIsChecked={checkboxIsChecked}
+                checkboxChange={onCheckboxChange}
+                dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
+            />
+        );
+    }
+
     componentWillUpdate(nextProps) {
         if (nextProps.rows !== this.props.rows) {
             this.setState({
@@ -381,20 +397,6 @@ class DynamicDataTable extends Component {
     }
 }
 
-const rowRenderer = ({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) => (
-    <DataRow
-        key={row.id}
-        row={row}
-        onClick={onClick}
-        buttons={buttons}
-        fields={fields}
-        renderCheckboxes={renderCheckboxes}
-        checkboxIsChecked={checkboxIsChecked}
-        checkboxChange={onCheckboxChange}
-        dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
-    />
-)
-
 DynamicDataTable.propTypes = {
     rows: PropTypes.array,
     fieldsToExclude: PropTypes.array,
@@ -437,7 +439,7 @@ DynamicDataTable.defaultProps = {
             }
         },
     ],
-    rowRenderer: rowRenderer,
+    rowRenderer: DynamicDataTable.rowRenderer,
 };
 
 export default DynamicDataTable;


### PR DESCRIPTION
Pass a function into `rowRenderer` that returns a `React.isValidElement`. Receive an object that contains the things required to rebuild/implement default functionality:
```js
{
  row, // Instance of row
  onClick, // On click handler
  buttons, // Array of buttons
  fields, // Visible fields
  renderCheckboxes, // Bool for rendering checkboxes
  checkboxIsChecked, // Check if checkbox is checked
  onCheckboxChange, // Function to add checkbox to state
  dataItemManipulator // Handle data manipulation
}
```

Closes #25 