### PR TITLE
Feature/onload callback

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -42,13 +42,15 @@ class AjaxDynamicDataTable extends Component {
   }
 
   loadPage(page) {
+    const axios = require('axios');
+
     const {
       orderByField,
       orderByDirection
     } = this.state;
-
-    const axios = require('axios');
-
+    const {
+      onLoad
+    } = this.props;
     axios.get(this.props.apiUrl, {
       params: {
         page,
@@ -61,11 +63,13 @@ class AjaxDynamicDataTable extends Component {
         last_page
       } = response.data.data;
       const rows = response.data.data.data;
-      this.setState({
+      const newState = {
         rows,
         currentPage: current_page,
         totalPages: last_page
-      });
+      };
+      this.setState(newState);
+      onLoad(newState);
     });
   }
 
@@ -84,7 +88,11 @@ class AjaxDynamicDataTable extends Component {
 
 }
 
+AjaxDynamicDataTable.defaultProps = {
+  onLoad: () => null
+};
 AjaxDynamicDataTable.propTypes = {
-  apiUrl: PropTypes.string
+  apiUrl: PropTypes.string,
+  onLoad: PropTypes.func
 };
 export default AjaxDynamicDataTable;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -43,8 +43,9 @@ class AjaxDynamicDataTable extends Component {
 
     loadPage(page) {
 
-        const {orderByField, orderByDirection} = this.state;
         const axios = require('axios');
+        const {orderByField, orderByDirection} = this.state;
+        const {onLoad} = this.props;
 
         axios.get(this.props.apiUrl, {
 
@@ -54,9 +55,10 @@ class AjaxDynamicDataTable extends Component {
 
             const {current_page, last_page} = response.data.data;
             const rows = response.data.data.data;
+            const newState = { rows, currentPage: current_page, totalPages: last_page };
 
-            this.setState({ rows, currentPage: current_page, totalPages: last_page });
-
+            this.setState(newState);
+            onLoad(newState);
         });
     }
 
@@ -74,8 +76,13 @@ class AjaxDynamicDataTable extends Component {
 
 }
 
+AjaxDynamicDataTable.defaultProps = {
+    onLoad: () => null,
+};
+
 AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
+    onLoad: PropTypes.func,
 };
 
 export default AjaxDynamicDataTable;


### PR DESCRIPTION
I have added the `onLoad` prop into the AJAX table to help with external changes to data, as it currently can't be reflected.

For instance creating an item, then wanting to push it to the rows- there's no way to "forcefully" update the current result set.

Here's an example usage:
We use `onLoad` to set the rows externally, this way we can add or remove rows and it will be reflected within the result set.
```jsx
<AjaxDynamicDataTable
    apiUrl="/api/storage/pallets"
    rows={pallets}
    onLoad={({ rows }) => this.setState({ pallets: rows })}
/>
```

A more complex example, with an actual use-case:
Here we have an abstract component that has a modal which creates pallets, but when a pallet is created we want to show it in the result set. `handleCreate` pushes to `pallets`.
```jsx
<SectionWithModal
    onCreate={submission => this.handleCreate(submission, 'pallet')}
    sectionTitle="Pallets"
    modalTitle="Create Pallet"
    buttonText="Create Pallet"
    form={CreatePalletForm({
        customers,
        locations,
        item_types,
        pallet_types,
    })}
>
    <AjaxDynamicDataTable
        apiUrl="/api/storage/pallets"
        rows={pallets}
        onLoad={({ rows }) => this.setState({ pallets: rows })}
        fieldsToExclude={FIELDS_TO_EXCLUDE.concat(['customer_id', 'location_id', 'item_type_id', 'pallet_type_id'])}
        dataItemManipulator={(field, value) => {
            switch (field) {
                case 'location':
                case 'pallet_type':
                case 'item_type':
                case 'customer':
                    return value.name;
                case 'invoice_occurrence':
                    return lodash.startCase(lodash.toLower(value));
                default:
                    return value || '';
            }
        }}
    />
</SectionWithModal>
```

We do not need an `onPageChange` prop as internally that calls `loadPage` which calls `onLoadPage`.