### PR TITLE
Add noDataComponent prop

### DIFF
--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -332,10 +332,13 @@ class DynamicDataTable extends Component {
   }
 
   renderEmptyTable() {
-    let noDataMessage = 'No data.';
+    const {
+      noDataMessage,
+      noDataComponent
+    } = this.props;
 
-    if (this.props.noDataMessage) {
-      noDataMessage = this.props.noDataMessage;
+    if (React.isValidElement(noDataComponent)) {
+      return noDataComponent;
     }
 
     return React.createElement("div", {
@@ -389,7 +392,7 @@ DynamicDataTable.defaultProps = {
   loadingMessage: '',
   loadingComponent: null,
   errorMessage: '',
-  noDataMessage: '',
+  noDataMessage: 'No data.',
   dataItemManipulator: (field, value) => {
     return value;
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -363,10 +363,10 @@ class DynamicDataTable extends Component {
 
     renderEmptyTable() {
 
-        let noDataMessage = 'No data.';
+        const { noDataMessage, noDataComponent } = this.props;
 
-        if (this.props.noDataMessage) {
-            noDataMessage = this.props.noDataMessage;
+        if (React.isValidElement(noDataComponent)) {
+            return noDataComponent;
         }
 
         return (
@@ -429,7 +429,7 @@ DynamicDataTable.defaultProps = {
     loadingMessage: '',
     loadingComponent: null,
     errorMessage: '',
-    noDataMessage: '',
+    noDataMessage: 'No data.',
     dataItemManipulator: (field, value) => { return value; },
     buttons: [
         {


### PR DESCRIPTION
I've implemented the _empty state_ prop as `noDataComponent`, this allows the table to be completely replaced when there is no data in the table.

```jsx
<DynamicDataTable
    rows={[]}
    noDataComponent={(
        <p>I replace the table, not just the text inside it</p>
    )}
/>
```