### PR TITLE
Add onContextMenu and hoverable props

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,11 +282,23 @@ In the example we will use our own [`@langleyfoxall/react-dynamic-context-menu`]
 ```JSX
 <DynamicDataTable
     rows={this.state.users}
-    rowRenderer={({ row, onContextMenu }) => (
+    rowRenderer={({ row }) => (
         <tr onContextMenu={() => onContextMenu(row)}>
             <td/>
         </tr>
     )}
+/>
+```
+
+### Hoverable table rows
+
+To enable a hover effect on rows even if `onClick` is not passed into the table you can use the prop `hoverable`.
+This will add a background color on each row when hovered.
+
+```JSX
+<DynamicDataTable
+    rows={this.state.users}
+    hoverable
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ In the example we will use our own [`@langleyfoxall/react-dynamic-context-menu`]
 <DynamicDataTable
     rows={this.state.users}
     rowRenderer={({ row }) => (
-        <tr onContextMenu={() => onContextMenu(row)}>
+        <tr onContextMenu={() => this.onContextMenu(row)}>
             <td/>
         </tr>
     )}

--- a/README.md
+++ b/README.md
@@ -215,18 +215,6 @@ An example of setting custom row buttons is shown below.
     />
 ```
 
-### Clickable rows
-
-Clickable rows allows an `onClick` prop to be passed which will return an instance of
-the row that is clicked. It also adds the bootstrap `table-hover` class onto the table.
-
-```JSX
-<DynamicDataTable
-    rows={this.state.users}
-    onClick={row => console.warn(row.name)}
-/>
-```
-
 ### Rendering custom rows
 
 If you come across a situation where the automatically generated rows are not suitable for your project
@@ -249,6 +237,58 @@ The argument passed to the `rowRenderer` callable is a JavaScript object that co
 ```
 
 For implementation details regarding these properties, see the other relevant areas of the documentatio.
+
+### Clickable rows
+
+Clickable rows allows an `onClick` prop to be passed which will return an instance of
+the row that is clicked. It also adds the bootstrap `table-hover` class onto the table.
+
+```JSX
+<DynamicDataTable
+    rows={this.state.users}
+    onClick={row => console.warn(row.name)}
+/>
+```
+
+The ability to right click rows can be enabled by using `onContextMenu` and `rowRenderer`.
+In the example we will use our own [`@langleyfoxall/react-dynamic-context-menu`](https://github.com/langleyfoxall/react-dynamic-context-menu):
+
+```JSX
+<DynamicDataTable
+    rows={this.state.users}
+    rowRenderer={options => (
+        <DynamicContextMenu
+            key={options.key}
+            data={options.row}
+            menuItems={[
+                {
+                    label: 'Update',
+                    onClick: this.handleUpdate,
+                },
+                {
+                    label: 'Delete',
+                    onClick: this.handleDelete,
+                },
+            ]}
+        >
+            {DynamicDataTable.rowRenderer(options)}
+        </DynamicContextMenu>
+    )}
+/>
+```
+
+`DynamicContextMenu` clones the child and adds `onContextMenu` as a prop. This can also be achieved manually.
+
+```JSX
+<DynamicDataTable
+    rows={this.state.users}
+    rowRenderer={({ row, onContextMenu }) => (
+        <tr onContextMenu={() => onContextMenu(row)}>
+            <td/>
+        </tr>
+    )}
+/>
+```
 
 ### Render no data component
 

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -2,23 +2,20 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class DataRow extends Component {
-  handleOnClick(row) {
-    const {
-      onClick
-    } = this.props;
-
-    if (!!onClick) {
-      return onClick(row);
-    }
+  static noop() {
+    return null;
   }
 
   render() {
     const {
       row,
-      fields
+      fields,
+      onClick,
+      onContextMenu
     } = this.props;
     return React.createElement("tr", {
-      onClick: () => this.handleOnClick(row)
+      onClick: () => onClick(row),
+      onContextMenu: e => onContextMenu(e, row)
     }, this.renderCheckboxCell(), fields.map(field => this.renderCell(field, row)), this.renderButtons(row));
   }
 
@@ -122,6 +119,10 @@ class DataRow extends Component {
 
 }
 
+DataRow.defaultProps = {
+  onClick: DataRow.noop,
+  onContextMenu: DataRow.noop
+};
 DataRow.propTypes = {
   row: PropTypes.object,
   buttons: PropTypes.array,
@@ -129,6 +130,7 @@ DataRow.propTypes = {
   checkboxChange: PropTypes.func,
   dataItemManipulator: PropTypes.func,
   renderCheckboxes: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  onContextMenu: PropTypes.func
 };
 export default DataRow;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -13,6 +13,10 @@ class DynamicDataTable extends Component {
     this.className = this.className.bind(this);
   }
 
+  static noop() {
+    return null;
+  }
+
   static rowRenderer({
     row,
     onClick,
@@ -46,10 +50,12 @@ class DynamicDataTable extends Component {
 
   className() {
     const {
-      onClick
+      onClick,
+      onContextMenu,
+      hoverable
     } = this.props;
     return classNames(['table', 'table-striped', {
-      'table-hover': !!onClick
+      'table-hover': onClick !== DynamicDataTable.noop || onContextMenu !== DynamicDataTable.noop || hoverable
     }]);
   }
 
@@ -425,7 +431,10 @@ DynamicDataTable.propTypes = {
   noDataComponent: PropTypes.element,
   dataItemManipulator: PropTypes.func,
   buttons: PropTypes.array,
-  rowRenderer: PropTypes.func
+  rowRenderer: PropTypes.func,
+  onClick: PropTypes.func,
+  onContextMenu: PropTypes.func,
+  hoverable: PropTypes.bool
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -453,6 +462,9 @@ DynamicDataTable.defaultProps = {
       window.location = `${location.href}/${row.id}`;
     }
   }],
-  rowRenderer: DynamicDataTable.rowRenderer
+  rowRenderer: DynamicDataTable.rowRenderer,
+  onClick: DynamicDataTable.noop,
+  onContextMenu: DynamicDataTable.noop,
+  hoverable: false
 };
 export default DynamicDataTable;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -20,6 +20,7 @@ class DynamicDataTable extends Component {
   static rowRenderer({
     row,
     onClick,
+    onContextMenu,
     buttons,
     fields,
     renderCheckboxes,
@@ -31,6 +32,7 @@ class DynamicDataTable extends Component {
       key: row.id,
       row: row,
       onClick: onClick,
+      onContextMenu: onContextMenu,
       buttons: buttons,
       fields: fields,
       renderCheckboxes: renderCheckboxes,
@@ -154,6 +156,7 @@ class DynamicDataTable extends Component {
   renderRow(row) {
     const {
       onClick,
+      onContextMenu,
       buttons,
       renderCheckboxes,
       dataItemManipulator,
@@ -162,6 +165,7 @@ class DynamicDataTable extends Component {
     return rowRenderer({
       row,
       onClick,
+      onContextMenu,
       buttons,
       renderCheckboxes,
       key: row.id,

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -20,7 +20,6 @@ class DynamicDataTable extends Component {
   static rowRenderer({
     row,
     onClick,
-    onContextMenu,
     buttons,
     fields,
     renderCheckboxes,
@@ -32,7 +31,6 @@ class DynamicDataTable extends Component {
       key: row.id,
       row: row,
       onClick: onClick,
-      onContextMenu: onContextMenu,
       buttons: buttons,
       fields: fields,
       renderCheckboxes: renderCheckboxes,
@@ -53,11 +51,10 @@ class DynamicDataTable extends Component {
   className() {
     const {
       onClick,
-      onContextMenu,
       hoverable
     } = this.props;
     return classNames(['table', 'table-striped', {
-      'table-hover': onClick !== DynamicDataTable.noop || onContextMenu !== DynamicDataTable.noop || hoverable
+      'table-hover': onClick !== DynamicDataTable.noop || hoverable
     }]);
   }
 
@@ -156,7 +153,6 @@ class DynamicDataTable extends Component {
   renderRow(row) {
     const {
       onClick,
-      onContextMenu,
       buttons,
       renderCheckboxes,
       dataItemManipulator,
@@ -165,7 +161,6 @@ class DynamicDataTable extends Component {
     return rowRenderer({
       row,
       onClick,
-      onContextMenu,
       buttons,
       renderCheckboxes,
       key: row.id,
@@ -437,7 +432,6 @@ DynamicDataTable.propTypes = {
   buttons: PropTypes.array,
   rowRenderer: PropTypes.func,
   onClick: PropTypes.func,
-  onContextMenu: PropTypes.func,
   hoverable: PropTypes.bool
 };
 DynamicDataTable.defaultProps = {
@@ -468,7 +462,6 @@ DynamicDataTable.defaultProps = {
   }],
   rowRenderer: DynamicDataTable.rowRenderer,
   onClick: DynamicDataTable.noop,
-  onContextMenu: DynamicDataTable.noop,
   hoverable: false
 };
 export default DynamicDataTable;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -3,19 +3,18 @@ import PropTypes from 'prop-types';
 
 class DataRow extends Component {
 
-    handleOnClick(row) {
-        const { onClick } = this.props;
-
-        if (!!onClick) {
-            return onClick(row);
-        }
+    static noop() {
+        return null;
     }
 
     render() {
-        const { row, fields } = this.props;
+        const { row, fields, onClick, onContextMenu } = this.props;
 
         return (
-            <tr onClick={() => this.handleOnClick(row)}>
+            <tr
+                onClick={() => onClick(row)}
+                onContextMenu={e => onContextMenu(e, row)}
+            >
                 { this.renderCheckboxCell() }
                 { fields.map(field => this.renderCell(field, row)) }
                 { this.renderButtons(row) }
@@ -119,6 +118,11 @@ class DataRow extends Component {
 
 }
 
+DataRow.defaultProps = {
+    onClick: DataRow.noop,
+    onContextMenu: DataRow.noop,
+};
+
 DataRow.propTypes = {
     row: PropTypes.object,
     buttons: PropTypes.array,
@@ -126,7 +130,8 @@ DataRow.propTypes = {
     checkboxChange: PropTypes.func,
     dataItemManipulator: PropTypes.func,
     renderCheckboxes: PropTypes.bool,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    onContextMenu: PropTypes.func,
 };
 
 export default DataRow;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -16,6 +16,10 @@ class DynamicDataTable extends Component {
         this.className = this.className.bind(this);
     }
 
+    static noop() {
+        return null;
+    }
+
     static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
         return (
             <DataRow
@@ -41,11 +45,16 @@ class DynamicDataTable extends Component {
     }
 
     className() {
-        const { onClick } = this.props;
+        const { onClick, onContextMenu, hoverable } = this.props;
 
         return classNames([
             'table', 'table-striped',
-            { 'table-hover': !!onClick }
+            {
+                'table-hover': 
+                    onClick !== DynamicDataTable.noop 
+                    || onContextMenu !== DynamicDataTable.noop
+                    || hoverable
+            }
         ]);
     }
 
@@ -452,6 +461,9 @@ DynamicDataTable.propTypes = {
     dataItemManipulator: PropTypes.func,
     buttons: PropTypes.array,
     rowRenderer: PropTypes.func,
+    onClick: PropTypes.func,
+    onContextMenu: PropTypes.func,
+    hoverable: PropTypes.bool,
 };
 
 DynamicDataTable.defaultProps = {
@@ -481,6 +493,9 @@ DynamicDataTable.defaultProps = {
         },
     ],
     rowRenderer: DynamicDataTable.rowRenderer,
+    onClick: DynamicDataTable.noop,
+    onContextMenu: DynamicDataTable.noop,
+    hoverable: false,
 };
 
 export default DynamicDataTable;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -20,13 +20,12 @@ class DynamicDataTable extends Component {
         return null;
     }
 
-    static rowRenderer({ row, onClick, onContextMenu, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
+    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
         return (
             <DataRow
                 key={row.id}
                 row={row}
                 onClick={onClick}
-                onContextMenu={onContextMenu}
                 buttons={buttons}
                 fields={fields}
                 renderCheckboxes={renderCheckboxes}
@@ -46,14 +45,13 @@ class DynamicDataTable extends Component {
     }
 
     className() {
-        const { onClick, onContextMenu, hoverable } = this.props;
+        const { onClick, hoverable } = this.props;
 
         return classNames([
             'table', 'table-striped',
             {
                 'table-hover': 
                     onClick !== DynamicDataTable.noop 
-                    || onContextMenu !== DynamicDataTable.noop
                     || hoverable
             }
         ]);
@@ -168,12 +166,11 @@ class DynamicDataTable extends Component {
     }
 
     renderRow(row) {
-        const { onClick, onContextMenu, buttons, renderCheckboxes, dataItemManipulator, rowRenderer } = this.props;
+        const { onClick, buttons, renderCheckboxes, dataItemManipulator, rowRenderer } = this.props;
 
         return rowRenderer({
             row,
             onClick,
-            onContextMenu,
             buttons,
             renderCheckboxes,
             key: row.id,
@@ -464,7 +461,6 @@ DynamicDataTable.propTypes = {
     buttons: PropTypes.array,
     rowRenderer: PropTypes.func,
     onClick: PropTypes.func,
-    onContextMenu: PropTypes.func,
     hoverable: PropTypes.bool,
 };
 
@@ -496,7 +492,6 @@ DynamicDataTable.defaultProps = {
     ],
     rowRenderer: DynamicDataTable.rowRenderer,
     onClick: DynamicDataTable.noop,
-    onContextMenu: DynamicDataTable.noop,
     hoverable: false,
 };
 

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -20,12 +20,13 @@ class DynamicDataTable extends Component {
         return null;
     }
 
-    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
+    static rowRenderer({ row, onClick, onContextMenu, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
         return (
             <DataRow
                 key={row.id}
                 row={row}
                 onClick={onClick}
+                onContextMenu={onContextMenu}
                 buttons={buttons}
                 fields={fields}
                 renderCheckboxes={renderCheckboxes}
@@ -167,11 +168,12 @@ class DynamicDataTable extends Component {
     }
 
     renderRow(row) {
-        const { onClick, buttons, renderCheckboxes, dataItemManipulator, rowRenderer } = this.props;
+        const { onClick, onContextMenu, buttons, renderCheckboxes, dataItemManipulator, rowRenderer } = this.props;
 
         return rowRenderer({
             row,
             onClick,
+            onContextMenu,
             buttons,
             renderCheckboxes,
             key: row.id,


### PR DESCRIPTION
I've implemented `onContextMenu` and `hoverable`. 

`hoverable` is used to add the `table-striped` class to the table even if there is no `onClick` or `onContextMenu` passed into the table. This would be used, for example, when using [@langleyfoxall/react-dynamic-context-menu](https://github.com/langleyfoxall/react-dynamic-context-menu) as the context menu component is used with `rowRender` rather than the table itself.

`onContextMenu` is used when wanting to add a right-click action on a row.

I've also added default values for `onClick`, `onContextMenu` and `hoverable`. Along with tweaking how adding `table-striped` works on `DynamicDataTable`.

This could be split up into many different pull requests, but everything is loosely based on getting `onContextMenu` to work (with minor tidy up).