### PR TITLE
Add params prop

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -94,11 +94,8 @@ function (_Component) {
     }
   }, {
     key: "componentDidUpdate",
-    value: function componentDidUpdate(_ref) {
-      var prevParams = _ref.params;
-      var currentParams = this.props.params;
-
-      if (JSON.stringify(prevParams) !== JSON.stringify(currentParams)) {
+    value: function componentDidUpdate(prevProps) {
+      if (JSON.stringify(prevProps.params) !== JSON.stringify(this.props.params)) {
         this.loadPage(1);
       }
     }

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -9,6 +9,16 @@ require("core-js/modules/es7.symbol.async-iterator");
 
 require("core-js/modules/es6.symbol");
 
+require("core-js/modules/es6.array.for-each");
+
+require("core-js/modules/es6.array.filter");
+
+require("core-js/modules/web.dom.iterable");
+
+require("core-js/modules/es6.array.iterator");
+
+require("core-js/modules/es6.object.keys");
+
 require("core-js/modules/es6.object.assign");
 
 require("core-js/modules/es6.object.define-property");
@@ -30,6 +40,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
@@ -79,6 +93,16 @@ function (_Component) {
       this.loadPage(1);
     }
   }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(_ref) {
+      var prevParams = _ref.params;
+      var currentParams = this.props.params;
+
+      if (JSON.stringify(prevParams) !== JSON.stringify(currentParams)) {
+        this.loadPage(1);
+      }
+    }
+  }, {
     key: "render",
     value: function render() {
       var _this$state = this.state,
@@ -109,16 +133,18 @@ function (_Component) {
       var _this$state2 = this.state,
           orderByField = _this$state2.orderByField,
           orderByDirection = _this$state2.orderByDirection;
-      var onLoad = this.props.onLoad;
+      var _this$props = this.props,
+          onLoad = _this$props.onLoad,
+          params = _this$props.params;
       this.setState({
         loading: true
       }, function () {
         axios.get(_this2.props.apiUrl, {
-          params: {
+          params: _objectSpread({}, params, {
             page: page,
             orderByField: orderByField,
             orderByDirection: orderByDirection
-          }
+          })
         }).then(function (response) {
           var _response$data$data = response.data.data,
               rows = _response$data$data.data,
@@ -162,11 +188,13 @@ function (_Component) {
 AjaxDynamicDataTable.defaultProps = {
   onLoad: function onLoad() {
     return null;
-  }
+  },
+  params: {}
 };
 AjaxDynamicDataTable.propTypes = {
   apiUrl: _propTypes.default.string,
-  onLoad: _propTypes.default.func
+  onLoad: _propTypes.default.func,
+  params: _propTypes.default.object
 };
 var _default = AjaxDynamicDataTable;
 exports.default = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -24,6 +24,14 @@ class AjaxDynamicDataTable extends Component {
         this.loadPage(1);
     }
 
+    componentDidUpdate({ params: prevParams }) {
+        const { params: currentParams } = this.props;
+
+        if (JSON.stringify(prevParams) !== JSON.stringify(currentParams)) {
+            this.loadPage(1);
+        }
+    }
+
     render() {
 
         const {rows, currentPage, totalPages, orderByField, orderByDirection, loading} = this.state;
@@ -47,14 +55,14 @@ class AjaxDynamicDataTable extends Component {
 
         const axios = require('axios');
         const {orderByField, orderByDirection} = this.state;
-        const {onLoad} = this.props;
+        const {onLoad, params} = this.props;
 
         this.setState(
             { loading: true },
             () => {
                 axios.get(this.props.apiUrl, {
 
-                    params: { page, orderByField, orderByDirection }
+                    params: { ...params, page, orderByField, orderByDirection }
         
                 }).then((response) => {
         
@@ -84,11 +92,13 @@ class AjaxDynamicDataTable extends Component {
 
 AjaxDynamicDataTable.defaultProps = {
     onLoad: () => null,
+    params: {},
 };
 
 AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
     onLoad: PropTypes.func,
+    params: PropTypes.object,
 };
 
 export default AjaxDynamicDataTable;

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -24,10 +24,8 @@ class AjaxDynamicDataTable extends Component {
         this.loadPage(1);
     }
 
-    componentDidUpdate({ params: prevParams }) {
-        const { params: currentParams } = this.props;
-
-        if (JSON.stringify(prevParams) !== JSON.stringify(currentParams)) {
+    componentDidUpdate(prevProps) {
+        if (JSON.stringify(prevProps.params) !== JSON.stringify(this.props.params)) {
             this.loadPage(1);
         }
     }


### PR DESCRIPTION
This PR adds the `params` prop to the `AjaxDynamicDataTable`. This is useful for filtering rows/passing query params to the axios request within the table component.

AJAX table (inside abstract view):
```jsx
<AjaxDynamicDataTable
    {...tableProps}
    apiUrl={apiUrl}
    params={apiParams}
    onLoad={onLoad}
/>
```

Top level component:
```jsx
onFilter({ target }) {
    const { timeout } = this.state;

    if (timeout) {
        clearTimeout(timeout);
    }

    this.setState({
        timeout: setTimeout(() => {
            this.setState({
                params: {
                    query: target.value,
                },
            });
        }, 250),
    });
}

// ...

render() {
    const { users, params } = this.state;

    return (
        <ListPageContainer
            apiUrl={'/api/users'}
            apiParams={params}
            onLoad={({ rows: users }) => this.setState({ users })}
            onFilter={this.onFilter}
            items={users}
        />
    );
}
```
