### PR TITLE
Feature/custom button render

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,43 @@ An example of setting custom row buttons is shown below.
     />
 ```
 
+`buttons` can also be given a custom render at the top level, or for multiple array elements.
+It's worth noting that multiple array elements still respect the dropdown menu.
+
+```jsx
+// Top level example
+<DynamicDataTable
+  buttons={row => (
+    <a>
+      <i className="fas fa-fw fa-eye" />
+      <span>Totally custom button</span>
+    </a>
+  )}
+/>
+
+// Low level example
+<DynamicDataTable
+  buttons={[
+    {
+      render: row => (
+        <a>
+          <i className="fas fa-fw fa-eye" />
+          <span>Totally custom button 1</span>
+        </a>
+      )
+    },
+    {
+      render: row => (
+        <a>
+          <i className="fas fa-fw fa-tick" />
+          <span>Totally custom button 2</span>
+        </a>
+      )
+    }
+  ]}
+/>
+```
+
 ### Rendering custom rows
 
 If you come across a situation where the automatically generated rows are not suitable for your project

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -137,16 +137,12 @@ function (_Component) {
         return _react.default.createElement("td", null);
       }
 
+      var button = buttons[0];
+
       if (buttons.length === 1) {
         return _react.default.createElement("td", {
           className: "rddt-action-cell"
-        }, _react.default.createElement("button", {
-          type: "button",
-          className: "btn btn-primary",
-          onClick: function onClick() {
-            buttons[0].callback(row);
-          }
-        }, buttons[0].name));
+        }, this.renderFirstButton(button, row));
       }
 
       return _react.default.createElement("td", {
@@ -156,13 +152,7 @@ function (_Component) {
         onClick: function onClick(e) {
           return e.stopPropagation();
         }
-      }, _react.default.createElement("button", {
-        type: "button",
-        className: "btn btn-primary",
-        onClick: function onClick() {
-          buttons[0].callback(row);
-        }
-      }, buttons[0].name), _react.default.createElement("button", {
+      }, this.renderFirstButton(button, row), _react.default.createElement("button", {
         type: "button",
         className: "btn btn-primary dropdown-toggle dropdown-toggle-split",
         "data-toggle": "dropdown",
@@ -178,10 +168,35 @@ function (_Component) {
       }))));
     }
   }, {
+    key: "renderFirstButton",
+    value: function renderFirstButton(button, row) {
+      if (typeof button.render === 'function') {
+        return button.render(row);
+      }
+
+      return _react.default.createElement("button", {
+        type: "button",
+        className: "btn btn-primary",
+        onClick: function onClick() {
+          button.callback(row);
+        }
+      }, button.name);
+    }
+  }, {
     key: "renderButton",
     value: function renderButton(button, index, row) {
       if (index === 0) {
         return;
+      }
+
+      if (typeof button.render === 'function') {
+        _react.default.createElement("div", {
+          style: {
+            cursor: 'pointer'
+          },
+          key: "button_".concat(button.name),
+          className: "dropdown-item"
+        }, button.render(row));
       }
 
       return _react.default.createElement("div", {

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -129,6 +129,10 @@ function (_Component) {
 
       var buttons = this.props.buttons;
 
+      if (typeof buttons === 'function') {
+        return buttons(row);
+      }
+
       if (!buttons.length) {
         return _react.default.createElement("td", null);
       }

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -612,7 +612,7 @@ DynamicDataTable.propTypes = {
   noDataMessage: _propTypes.default.string,
   noDataComponent: _propTypes.default.element,
   dataItemManipulator: _propTypes.default.func,
-  buttons: _propTypes.default.array,
+  buttons: _propTypes.default.oneOfType([_propTypes.default.array, _propTypes.default.func]),
   rowRenderer: _propTypes.default.func,
   onClick: _propTypes.default.func,
   hoverable: _propTypes.default.bool

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -60,7 +60,11 @@ class DataRow extends Component {
     }
 
     renderButtons(row) {
-        const buttons = this.props.buttons;
+        const { buttons } = this.props;
+
+        if (typeof buttons === 'function') {
+            return buttons(row);
+        }
 
         if (!buttons.length) {
             return ( <td></td> );

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -70,13 +70,12 @@ class DataRow extends Component {
             return ( <td></td> );
         }
 
+        const button = buttons[0];
+
         if (buttons.length===1) {
             return (
                 <td className="rddt-action-cell">
-                    <button type="button" className="btn btn-primary"
-                            onClick={() => { buttons[0].callback(row) }}>
-                        { buttons[0].name }
-                    </button>
+                    {this.renderFirstButton(button, row)}
                 </td>
             )
         }
@@ -87,10 +86,7 @@ class DataRow extends Component {
                     className="btn-group"
                     onClick={e => e.stopPropagation()}
                 >
-                    <button type="button" className="btn btn-primary"
-                            onClick={() => { buttons[0].callback(row) }}>
-                        { buttons[0].name }
-                    </button>
+                    {this.renderFirstButton(button, row)}
                     <button type="button" className="btn btn-primary dropdown-toggle dropdown-toggle-split"
                             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <span className="sr-only">Toggle Dropdown</span>
@@ -103,10 +99,35 @@ class DataRow extends Component {
         );
     }
 
+    renderFirstButton(button, row) {
+        if (typeof button.render === 'function') {
+            return button.render(row)
+        }
+
+       return (
+            <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => { button.callback(row) }}
+            >
+                {button.name}
+            </button>
+       )
+    }
+
     renderButton(button, index, row) {
 
         if (index===0) {
             return;
+        }
+
+        if (typeof button.render === 'function') {
+            <div
+                style={{cursor: 'pointer'}}
+                key={`button_${button.name}`}
+                className="dropdown-item">
+                {button.render(row)}
+            </div>
         }
 
         return (
@@ -115,7 +136,7 @@ class DataRow extends Component {
                 key={`button_${button.name}`}
                 className="dropdown-item"
                 onClick={() => { button.callback(row) }}>
-                { button.name }
+                {button.name}
             </div>
         )
     }

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -513,7 +513,9 @@ DynamicDataTable.propTypes = {
     noDataMessage: PropTypes.string,
     noDataComponent: PropTypes.element,
     dataItemManipulator: PropTypes.func,
-    buttons: PropTypes.array,
+    buttons: PropTypes.oneOfType([
+        PropTypes.array, PropTypes.func,
+    ]),
     rowRenderer: PropTypes.func,
     onClick: PropTypes.func,
     hoverable: PropTypes.bool,


### PR DESCRIPTION
Allow `render` to be passed at the top level of the `buttons` prop and allow `render` to be passed into each button element. Previously you would have to pass in a `rowRenderer` prop and handle each `td` manually to simply append fully custom buttons at the end of a row.

When multiple buttons are passed, even with a custom `render`, it still respects the dropdown that appears.

```jsx
// Top level example
<DynamicDataTable
  buttons={row => (
    <a>
      <i className="fas fa-fw fa-eye" />
      <span>Totally custom button</span>
    </a>
  )}
/>

// Low level example
<DynamicDataTable
  buttons={[
    {
      render: row => (
        <a>
          <i className="fas fa-fw fa-eye" />
          <span>Totally custom button 1</span>
        </a>
      )
    },
    {
      render: row => (
        <a>
          <i className="fas fa-fw fa-tick" />
          <span>Totally custom button 2</span>
        </a>
      )
    }
  ]}
/>
```

This would be an extremely helpful feature and save my current project a lot of time if implemented.