### PR TITLE
Adds default sorting props to AjaxDynamicDataTable

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -74,12 +74,14 @@ function (_Component) {
     _classCallCheck(this, AjaxDynamicDataTable);
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(AjaxDynamicDataTable).call(this, props));
+    var defaultOrderByField = props.defaultOrderByField,
+        defaultOrderByDirection = props.defaultOrderByDirection;
     _this.state = {
       rows: [],
       currentPage: 1,
       totalPages: 1,
-      orderByField: _this.props.defaultOrderByField,
-      orderByDirection: _this.props.defaultOrderByDirection,
+      orderByField: defaultOrderByField,
+      orderByDirection: defaultOrderByDirection,
       loading: false
     };
     _this.changePage = _this.changePage.bind(_assertThisInitialized(_assertThisInitialized(_this)));

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -68,18 +68,18 @@ var AjaxDynamicDataTable =
 function (_Component) {
   _inherits(AjaxDynamicDataTable, _Component);
 
-  function AjaxDynamicDataTable() {
+  function AjaxDynamicDataTable(props) {
     var _this;
 
     _classCallCheck(this, AjaxDynamicDataTable);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(AjaxDynamicDataTable).call(this));
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(AjaxDynamicDataTable).call(this, props));
     _this.state = {
       rows: [],
       currentPage: 1,
       totalPages: 1,
-      orderByField: null,
-      orderByDirection: null,
+      orderByField: _this.props.defaultOrderByField,
+      orderByDirection: _this.props.defaultOrderByDirection,
       loading: false
     };
     _this.changePage = _this.changePage.bind(_assertThisInitialized(_assertThisInitialized(_this)));
@@ -186,12 +186,16 @@ AjaxDynamicDataTable.defaultProps = {
   onLoad: function onLoad() {
     return null;
   },
-  params: {}
+  params: {},
+  defaultOrderByField: null,
+  defaultOrderByDirection: null
 };
 AjaxDynamicDataTable.propTypes = {
   apiUrl: _propTypes.default.string,
   onLoad: _propTypes.default.func,
-  params: _propTypes.default.object
+  params: _propTypes.default.object,
+  defaultOrderByField: _propTypes.default.string,
+  defaultOrderByDirection: _propTypes.default.string
 };
 var _default = AjaxDynamicDataTable;
 exports.default = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -11,7 +11,7 @@ class AjaxDynamicDataTable extends Component {
             rows: [],
             currentPage: 1,
             totalPages: 1,
-            orderByField: this.props.defaultOrderByField,
+            orderByField: props.defaultOrderByField,
             orderByDirection: this.props.defaultOrderByDirection,
             loading: false,
         };

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -12,7 +12,7 @@ class AjaxDynamicDataTable extends Component {
             currentPage: 1,
             totalPages: 1,
             orderByField: props.defaultOrderByField,
-            orderByDirection: this.props.defaultOrderByDirection,
+            orderByDirection: props.defaultOrderByDirection,
             loading: false,
         };
 

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -6,13 +6,14 @@ class AjaxDynamicDataTable extends Component {
 
     constructor(props) {
         super(props);
+        const { defaultOrderByField, defaultOrderByDirection } = props;
 
         this.state = {
             rows: [],
             currentPage: 1,
             totalPages: 1,
-            orderByField: props.defaultOrderByField,
-            orderByDirection: props.defaultOrderByDirection,
+            orderByField: defaultOrderByField,
+            orderByDirection: defaultOrderByDirection,
             loading: false,
         };
 

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -4,15 +4,15 @@ import DynamicDataTable from "./DynamicDataTable";
 
 class AjaxDynamicDataTable extends Component {
 
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         this.state = {
             rows: [],
             currentPage: 1,
             totalPages: 1,
-            orderByField: null,
-            orderByDirection: null,
+            orderByField: this.props.defaultOrderByField,
+            orderByDirection: this.props.defaultOrderByDirection,
             loading: false,
         };
 
@@ -91,12 +91,16 @@ class AjaxDynamicDataTable extends Component {
 AjaxDynamicDataTable.defaultProps = {
     onLoad: () => null,
     params: {},
+    defaultOrderByField: null,
+    defaultOrderByDirection: null,
 };
 
 AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
     onLoad: PropTypes.func,
     params: PropTypes.object,
+    defaultOrderByField: PropTypes.string,
+    defaultOrderByDirection: PropTypes.string,
 };
 
 export default AjaxDynamicDataTable;


### PR DESCRIPTION
This PR adds two additional props that allows you to set a default sort order an Ajax Dynamic Datatable without needing to re-implement the sorting logic code in the parent control.

Example Usage:
```jsx
<AjaxDynamicDataTable apiUrl={route('admin.company.datatable').toString()} 
defaultOrderByField="name"
defaultOrderByDirection="asc"/>
```