### PR TITLE
Add reload function to be used with refs

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -84,6 +84,7 @@ function (_Component) {
       orderByDirection: defaultOrderByDirection,
       loading: false
     };
+    _this.reload = _this.reload.bind(_assertThisInitialized(_assertThisInitialized(_this)));
     _this.changePage = _this.changePage.bind(_assertThisInitialized(_assertThisInitialized(_this)));
     _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_assertThisInitialized(_this)));
     return _this;
@@ -121,6 +122,12 @@ function (_Component) {
         changePage: this.changePage,
         changeOrder: this.changeOrder
       }, this.props));
+    }
+  }, {
+    key: "reload",
+    value: function reload() {
+      var page = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
+      this.loadPage(page);
     }
   }, {
     key: "loadPage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -17,6 +17,7 @@ class AjaxDynamicDataTable extends Component {
             loading: false,
         };
 
+        this.reload = this.reload.bind(this);
         this.changePage = this.changePage.bind(this);
         this.changeOrder = this.changeOrder.bind(this);
     }
@@ -48,6 +49,10 @@ class AjaxDynamicDataTable extends Component {
                 {...this.props}
             />
         );
+    }
+
+    reload(page = 1) {
+        this.loadPage(page);
     }
 
     loadPage(page) {


### PR DESCRIPTION
This function makes for nicer syntax when forcing a reload of the data from outside of the table.

Creating a ref:
```jsx
this.table = React.createRef()
```

Setting the ref:
```jsx
<DataTable
  ref={this.table}
/>
```

Using the ref:
```jsx
this.table.current.reload()

// or
this.table.current.reload(2)
```

[Ref documentation](https://reactjs.org/docs/refs-and-the-dom.html)