### PR TITLE
Feature: Whitelist for Order By 

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ and `direction` parameters respectively.
 2. Change / re-retrieve the `rows` prop, such that it is sorted based on the passed 
 `field` and `direction` parameters.
 
+Ordering data is enabled for all fields by default. However, if you wish to restrict 
+which fields the ordering is enabled for, pass an array of the field names into the 
+`allowOrderingBy` prop. An example of this is shown below.
+
+```JSX
+<AjaxDynamicDataTable
+    rows={this.state.users}
+    allowOrderingBy={[
+        'name', 'email'
+    ]}
+/>
+```
+
 ### Ordering fields
 
 By default fields will be ordered as they are passed into the table on each row.

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -57,11 +57,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var AjaxDynamicDataTable =
 /*#__PURE__*/
@@ -84,9 +84,9 @@ function (_Component) {
       orderByDirection: defaultOrderByDirection,
       loading: false
     };
-    _this.reload = _this.reload.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.changePage = _this.changePage.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.reload = _this.reload.bind(_assertThisInitialized(_this));
+    _this.changePage = _this.changePage.bind(_assertThisInitialized(_this));
+    _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_this));
     return _this;
   }
 

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -17,6 +17,10 @@ require("core-js/modules/es6.object.set-prototype-of");
 
 require("core-js/modules/es6.array.for-each");
 
+require("core-js/modules/es7.array.includes");
+
+require("core-js/modules/es6.string.includes");
+
 require("core-js/modules/es6.array.map");
 
 require("core-js/modules/es6.array.is-array");
@@ -69,11 +73,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var DynamicDataTable =
 /*#__PURE__*/
@@ -89,7 +93,7 @@ function (_Component) {
     _this.state = {
       checkedRows: []
     };
-    _this.className = _this.className.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.className = _this.className.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -315,14 +319,17 @@ function (_Component) {
         orderByIcon = props.orderByDirection === 'asc' ? '↓' : '↑';
       }
 
+      var canOrderBy = props.orderByWhitelist.length === 0 || props.orderByWhitelist.includes(field.name);
+      var onClickHandler = canOrderBy ? function () {
+        return _this4.changeOrder(field);
+      } : function () {};
+      var cursor = props.changeOrder && canOrderBy ? 'pointer' : 'default';
       return _react.default.createElement("th", {
         style: {
-          cursor: props.changeOrder ? 'pointer' : 'default'
+          cursor: cursor
         },
         key: field.name,
-        onClick: function onClick() {
-          return _this4.changeOrder(field);
-        }
+        onClick: onClickHandler
       }, field.label, "\xA0", orderByIcon);
     }
   }, {
@@ -615,7 +622,8 @@ DynamicDataTable.propTypes = {
   buttons: _propTypes.default.oneOfType([_propTypes.default.array, _propTypes.default.func]),
   rowRenderer: _propTypes.default.func,
   onClick: _propTypes.default.func,
-  hoverable: _propTypes.default.bool
+  hoverable: _propTypes.default.bool,
+  orderByWhitelist: _propTypes.default.array
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -646,7 +654,8 @@ DynamicDataTable.defaultProps = {
   }],
   rowRenderer: DynamicDataTable.rowRenderer,
   onClick: DynamicDataTable.noop,
-  hoverable: false
+  hoverable: false,
+  orderByWhitelist: []
 };
 var _default = DynamicDataTable;
 exports.default = _default;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -243,7 +243,7 @@ class DynamicDataTable extends Component {
             orderByIcon = (props.orderByDirection === 'asc') ? '↓' : '↑';
         }
         
-        const canOrderBy = props.orderByWhitelist.length === 0 || props.orderByWhitelist.includes(field.name);
+        const canOrderBy = props.allowOrderingBy.length === 0 || props.allowOrderingBy.includes(field.name);
 
         const onClickHandler = canOrderBy
             ? () => this.changeOrder(field)
@@ -527,7 +527,7 @@ DynamicDataTable.propTypes = {
     rowRenderer: PropTypes.func,
     onClick: PropTypes.func,
     hoverable: PropTypes.bool,
-    orderByWhitelist: PropTypes.array,
+    allowOrderingBy: PropTypes.array,
 };
 
 DynamicDataTable.defaultProps = {
@@ -560,7 +560,7 @@ DynamicDataTable.defaultProps = {
     rowRenderer: DynamicDataTable.rowRenderer,
     onClick: DynamicDataTable.noop,
     hoverable: false,
-    orderByWhitelist: [],
+    allowOrderingBy: [],
 };
 
 export default DynamicDataTable;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -242,9 +242,17 @@ class DynamicDataTable extends Component {
         if (props.orderByField === field.name) {
             orderByIcon = (props.orderByDirection === 'asc') ? '↓' : '↑';
         }
+        
+        const canOrderBy = props.orderByWhitelist.length === 0 || props.orderByWhitelist.includes(field.name);
 
+        const onClickHandler = canOrderBy
+            ? () => this.changeOrder(field)
+            : () => {};
+        
+        const cursor = props.changeOrder && canOrderBy ? 'pointer' : 'default';
+        
         return (
-            <th style={{ cursor: (props.changeOrder ? 'pointer' : 'default') }} key={field.name} onClick={() => this.changeOrder(field)}>
+            <th style={{ cursor }} key={field.name} onClick={onClickHandler}>
                 { field.label }
                 &nbsp;
                 { orderByIcon }
@@ -519,6 +527,7 @@ DynamicDataTable.propTypes = {
     rowRenderer: PropTypes.func,
     onClick: PropTypes.func,
     hoverable: PropTypes.bool,
+    orderByWhitelist: PropTypes.array,
 };
 
 DynamicDataTable.defaultProps = {
@@ -551,6 +560,7 @@ DynamicDataTable.defaultProps = {
     rowRenderer: DynamicDataTable.rowRenderer,
     onClick: DynamicDataTable.noop,
     hoverable: false,
+    orderByWhitelist: [],
 };
 
 export default DynamicDataTable;


### PR DESCRIPTION
This PR provides the ability for a user to specify an `allowOrderingBy` prop on either an `AjaxDynamicDataTable` or a `DynamicDataTable` which prevents the header from allowing ordering of columns not contained within the whitelist.

Example:
```js
<AjaxDynamicDataTable
  apiUrl={datatableUrl}
  allowOrderingBy={[
    'type', 'first_name', 'last_name'
  ]}
/>
```