### PR TITLE
Provide access to all row data within dataItemManipulator callback

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -3,19 +3,21 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
-
-require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.array.for-each");
 
 require("core-js/modules/es6.array.filter");
 
+require("core-js/modules/es6.symbol");
+
 require("core-js/modules/web.dom.iterable");
 
 require("core-js/modules/es6.array.iterator");
+
+require("core-js/modules/es6.object.to-string");
 
 require("core-js/modules/es6.object.keys");
 
@@ -35,9 +37,9 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _DynamicDataTable = _interopRequireDefault(require("./DynamicDataTable"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -57,11 +59,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var AjaxDynamicDataTable =
 /*#__PURE__*/
@@ -84,9 +86,9 @@ function (_Component) {
       orderByDirection: defaultOrderByDirection,
       loading: false
     };
-    _this.reload = _this.reload.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.changePage = _this.changePage.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.reload = _this.reload.bind(_assertThisInitialized(_this));
+    _this.changePage = _this.changePage.bind(_assertThisInitialized(_this));
+    _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -112,7 +114,7 @@ function (_Component) {
           orderByField = _this$state.orderByField,
           orderByDirection = _this$state.orderByDirection,
           loading = _this$state.loading;
-      return _react.default.createElement(_DynamicDataTable.default, _extends({
+      return _react["default"].createElement(_DynamicDataTable["default"], _extends({
         rows: rows,
         currentPage: currentPage,
         totalPages: totalPages,
@@ -200,11 +202,11 @@ AjaxDynamicDataTable.defaultProps = {
   defaultOrderByDirection: null
 };
 AjaxDynamicDataTable.propTypes = {
-  apiUrl: _propTypes.default.string,
-  onLoad: _propTypes.default.func,
-  params: _propTypes.default.object,
-  defaultOrderByField: _propTypes.default.string,
-  defaultOrderByDirection: _propTypes.default.string
+  apiUrl: _propTypes["default"].string,
+  onLoad: _propTypes["default"].func,
+  params: _propTypes["default"].object,
+  defaultOrderByField: _propTypes["default"].string,
+  defaultOrderByDirection: _propTypes["default"].string
 };
 var _default = AjaxDynamicDataTable;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -23,9 +23,9 @@ var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -66,7 +66,7 @@ function (_Component) {
           fields = _this$props.fields,
           _onClick = _this$props.onClick,
           _onContextMenu = _this$props.onContextMenu;
-      return _react.default.createElement("tr", {
+      return _react["default"].createElement("tr", {
         onClick: function onClick() {
           return _onClick(row);
         },
@@ -90,9 +90,9 @@ function (_Component) {
         return;
       }
 
-      var checkbox = _react.default.createElement("div", {
+      var checkbox = _react["default"].createElement("div", {
         className: "form-check"
-      }, _react.default.createElement("input", {
+      }, _react["default"].createElement("input", {
         type: "checkbox",
         checked: this.props.checkboxIsChecked(row),
         onChange: function onChange(event) {
@@ -106,19 +106,19 @@ function (_Component) {
         }
       }));
 
-      return _react.default.createElement("td", null, checkbox);
+      return _react["default"].createElement("td", null, checkbox);
     }
   }, {
     key: "renderCell",
     value: function renderCell(field, row) {
       var value = row[field.name];
-      value = this.props.dataItemManipulator(field.name, value);
+      value = this.props.dataItemManipulator(field.name, value, row);
 
       if (_typeof(value) === 'object' || typeof value === 'array') {
         value = JSON.stringify(value);
       }
 
-      return _react.default.createElement("td", {
+      return _react["default"].createElement("td", {
         key: "".concat(row.id, "_").concat(field.name)
       }, value);
     }
@@ -134,33 +134,33 @@ function (_Component) {
       }
 
       if (!buttons.length) {
-        return _react.default.createElement("td", null);
+        return _react["default"].createElement("td", null);
       }
 
       var button = buttons[0];
 
       if (buttons.length === 1) {
-        return _react.default.createElement("td", {
+        return _react["default"].createElement("td", {
           className: "rddt-action-cell"
         }, this.renderFirstButton(button, row));
       }
 
-      return _react.default.createElement("td", {
+      return _react["default"].createElement("td", {
         className: "rddt-action-cell"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "btn-group",
         onClick: function onClick(e) {
           return e.stopPropagation();
         }
-      }, this.renderFirstButton(button, row), _react.default.createElement("button", {
+      }, this.renderFirstButton(button, row), _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary dropdown-toggle dropdown-toggle-split",
         "data-toggle": "dropdown",
         "aria-haspopup": "true",
         "aria-expanded": "false"
-      }, _react.default.createElement("span", {
+      }, _react["default"].createElement("span", {
         className: "sr-only"
-      }, "Toggle Dropdown")), _react.default.createElement("div", {
+      }, "Toggle Dropdown")), _react["default"].createElement("div", {
         className: "dropdown-menu",
         "aria-labelledby": "dropdownMenuButton"
       }, buttons.map(function (button, index) {
@@ -174,7 +174,7 @@ function (_Component) {
         return button.render(row);
       }
 
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary",
         onClick: function onClick() {
@@ -190,7 +190,7 @@ function (_Component) {
       }
 
       if (typeof button.render === 'function') {
-        _react.default.createElement("div", {
+        _react["default"].createElement("div", {
           style: {
             cursor: 'pointer'
           },
@@ -199,7 +199,7 @@ function (_Component) {
         }, button.render(row));
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         style: {
           cursor: 'pointer'
         },
@@ -225,14 +225,14 @@ DataRow.defaultProps = {
   onContextMenu: DataRow.noop
 };
 DataRow.propTypes = {
-  row: _propTypes.default.object,
-  buttons: _propTypes.default.oneOfType([_propTypes.default.array, _propTypes.default.func]),
-  checkboxIsChecked: _propTypes.default.func,
-  checkboxChange: _propTypes.default.func,
-  dataItemManipulator: _propTypes.default.func,
-  renderCheckboxes: _propTypes.default.bool,
-  onClick: _propTypes.default.func,
-  onContextMenu: _propTypes.default.func
+  row: _propTypes["default"].object,
+  buttons: _propTypes["default"].oneOfType([_propTypes["default"].array, _propTypes["default"].func]),
+  checkboxIsChecked: _propTypes["default"].func,
+  checkboxChange: _propTypes["default"].func,
+  dataItemManipulator: _propTypes["default"].func,
+  renderCheckboxes: _propTypes["default"].bool,
+  onClick: _propTypes["default"].func,
+  onContextMenu: _propTypes["default"].func
 };
 var _default = DataRow;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/Components/Pagination.js
+++ b/dist/Components/Pagination.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -19,9 +19,9 @@ var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -67,10 +67,10 @@ function (_Component) {
       }
 
       var _loop = function _loop(i) {
-        pageLinks.push(_react.default.createElement("li", {
+        pageLinks.push(_react["default"].createElement("li", {
           key: "page_".concat(i),
           className: "page-item ".concat(currentPage === i ? 'active' : '')
-        }, _react.default.createElement("button", {
+        }, _react["default"].createElement("button", {
           type: "button",
           className: "page-link",
           onClick: function onClick() {
@@ -83,21 +83,21 @@ function (_Component) {
         _loop(i);
       }
 
-      return _react.default.createElement("nav", {
+      return _react["default"].createElement("nav", {
         "aria-label": "Page navigation"
-      }, _react.default.createElement("ul", {
+      }, _react["default"].createElement("ul", {
         className: "pagination"
-      }, _react.default.createElement("li", {
+      }, _react["default"].createElement("li", {
         className: "page-item ".concat(currentPage <= 1 ? 'disabled' : '')
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "page-link",
         onClick: function onClick() {
           return _this.previousPage();
         }
-      }, "Previous")), pageLinks, _react.default.createElement("li", {
+      }, "Previous")), pageLinks, _react["default"].createElement("li", {
         className: "page-item ".concat(currentPage >= totalPages ? 'disabled' : '')
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "page-link",
         onClick: function onClick() {
@@ -130,9 +130,9 @@ function (_Component) {
 }(_react.Component);
 
 Pagination.propTypes = {
-  currentPage: _propTypes.default.number,
-  totalPages: _propTypes.default.number,
-  changePage: _propTypes.default.func
+  currentPage: _propTypes["default"].number,
+  totalPages: _propTypes["default"].number,
+  changePage: _propTypes["default"].func
 };
 var _default = Pagination;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -43,6 +43,8 @@ require("core-js/modules/web.dom.iterable");
 
 require("core-js/modules/es6.array.iterator");
 
+require("core-js/modules/es6.object.to-string");
+
 require("core-js/modules/es6.object.keys");
 
 require("core-js/modules/es6.function.bind");
@@ -57,9 +59,9 @@ var _DataRow = _interopRequireDefault(require("./Components/DataRow"));
 
 var _Pagination = _interopRequireDefault(require("./Components/Pagination"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -73,11 +75,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var DynamicDataTable =
 /*#__PURE__*/
@@ -93,7 +95,7 @@ function (_Component) {
     _this.state = {
       checkedRows: []
     };
-    _this.className = _this.className.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.className = _this.className.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -112,7 +114,7 @@ function (_Component) {
       var _this$props = this.props,
           onClick = _this$props.onClick,
           hoverable = _this$props.hoverable;
-      return (0, _classnames.default)(['table', 'table-striped', {
+      return (0, _classnames["default"])(['table', 'table-striped', {
         'table-hover': onClick !== DynamicDataTable.noop || hoverable
       }]);
     }
@@ -268,13 +270,13 @@ function (_Component) {
         return this.renderEmptyTable();
       }
 
-      return _react.default.createElement("div", null, _react.default.createElement("div", {
+      return _react["default"].createElement("div", null, _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: this.className()
-      }, _react.default.createElement("thead", null, _react.default.createElement("tr", null, this.renderCheckboxCell('all'), fields.map(function (field) {
+      }, _react["default"].createElement("thead", null, _react["default"].createElement("tr", null, this.renderCheckboxCell('all'), fields.map(function (field) {
         return _this2.renderHeader(field);
-      }), this.renderActionsCell())), _react.default.createElement("tbody", null, rows.map(function (row) {
+      }), this.renderActionsCell())), _react["default"].createElement("tbody", null, rows.map(function (row) {
         return _this2.renderRow(row);
       })))), this.renderPagination());
     }
@@ -296,8 +298,8 @@ function (_Component) {
         renderCheckboxes: renderCheckboxes,
         key: row.id,
         fields: this.getFields(),
-        dataItemManipulator: function dataItemManipulator(field, value) {
-          return _dataItemManipulator(field, value);
+        dataItemManipulator: function dataItemManipulator(field, value, row) {
+          return _dataItemManipulator(field, value, row);
         },
         checkboxIsChecked: function checkboxIsChecked(value) {
           return _this3.checkboxIsChecked(value);
@@ -329,7 +331,7 @@ function (_Component) {
         return _this4.changeOrder(field);
       } : function () {};
       var cursor = changeOrder && canOrderBy ? 'pointer' : 'default';
-      return _react.default.createElement("th", {
+      return _react["default"].createElement("th", {
         style: {
           cursor: cursor
         },
@@ -346,14 +348,14 @@ function (_Component) {
       var state = this.state;
 
       if (!props.renderCheckboxes || !this.props.actions.length) {
-        return _react.default.createElement("th", null);
+        return _react["default"].createElement("th", null);
       }
 
-      return _react.default.createElement("th", {
+      return _react["default"].createElement("th", {
         className: "rddt-action-cell"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "dropdown"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         className: "btn btn-secondary dropdown-toggle",
         type: "button",
         id: "dropdownMenuButton",
@@ -361,7 +363,7 @@ function (_Component) {
         "aria-haspopup": "true",
         "aria-expanded": "false",
         disabled: !state.checkedRows.length
-      }, "Actions"), _react.default.createElement("div", {
+      }, "Actions"), _react["default"].createElement("div", {
         className: "dropdown-menu",
         "aria-labelledby": "dropdownMenuButton"
       }, this.props.actions.map(function (action) {
@@ -373,7 +375,7 @@ function (_Component) {
     value: function renderActionButton(action) {
       var _this6 = this;
 
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         key: "action_".concat(action.name),
         type: "button",
         className: "dropdown-item",
@@ -411,9 +413,9 @@ function (_Component) {
         return;
       }
 
-      var checkbox = _react.default.createElement("div", {
+      var checkbox = _react["default"].createElement("div", {
         className: "form-check"
-      }, _react.default.createElement("input", {
+      }, _react["default"].createElement("input", {
         type: "checkbox",
         value: value,
         checked: this.checkboxIsChecked(value),
@@ -426,10 +428,10 @@ function (_Component) {
       }));
 
       if (value === 'all') {
-        return _react.default.createElement("th", null, checkbox);
+        return _react["default"].createElement("th", null, checkbox);
       }
 
-      return _react.default.createElement("td", null, checkbox);
+      return _react["default"].createElement("td", null, checkbox);
     }
   }, {
     key: "checkboxIsChecked",
@@ -520,22 +522,22 @@ function (_Component) {
         return loadingComponent;
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: "table table-striped"
-      }, _react.default.createElement("tbody", null, _react.default.createElement("tr", null, _react.default.createElement("td", {
+      }, _react["default"].createElement("tbody", null, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
         className: "text-center"
-      }, !!loadingIndicator && _react.default.createElement("div", null, loadingIndicator), !!loadingMessage && _react.default.createElement("div", null, loadingMessage))))));
+      }, !!loadingIndicator && _react["default"].createElement("div", null, loadingIndicator), !!loadingMessage && _react["default"].createElement("div", null, loadingMessage))))));
     }
   }, {
     key: "renderErrorTable",
     value: function renderErrorTable() {
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: "table table-striped"
-      }, _react.default.createElement("tbody", null, _react.default.createElement("tr", null, _react.default.createElement("td", {
+      }, _react["default"].createElement("tbody", null, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
         className: "text-center"
       }, this.props.errorMessage)))));
     }
@@ -546,15 +548,15 @@ function (_Component) {
           noDataMessage = _this$props7.noDataMessage,
           noDataComponent = _this$props7.noDataComponent;
 
-      if (_react.default.isValidElement(noDataComponent)) {
+      if (_react["default"].isValidElement(noDataComponent)) {
         return noDataComponent;
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: "table table-striped"
-      }, _react.default.createElement("tbody", null, _react.default.createElement("tr", null, _react.default.createElement("td", {
+      }, _react["default"].createElement("tbody", null, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
         className: "text-center"
       }, noDataMessage)))));
     }
@@ -562,7 +564,7 @@ function (_Component) {
     key: "renderPagination",
     value: function renderPagination() {
       var props = this.props;
-      return _react.default.createElement(_Pagination.default, {
+      return _react["default"].createElement(_Pagination["default"], {
         currentPage: props.currentPage,
         totalPages: props.totalPages,
         changePage: function changePage(page) {
@@ -586,7 +588,7 @@ function (_Component) {
           checkboxIsChecked = _ref2.checkboxIsChecked,
           onCheckboxChange = _ref2.onCheckboxChange,
           _dataItemManipulator2 = _ref2.dataItemManipulator;
-      return _react.default.createElement(_DataRow.default, {
+      return _react["default"].createElement(_DataRow["default"], {
         key: row.id,
         row: row,
         onClick: onClick,
@@ -595,8 +597,8 @@ function (_Component) {
         renderCheckboxes: renderCheckboxes,
         checkboxIsChecked: checkboxIsChecked,
         checkboxChange: onCheckboxChange,
-        dataItemManipulator: function dataItemManipulator(field, value) {
-          return _dataItemManipulator2(field, value);
+        dataItemManipulator: function dataItemManipulator(field, value, row) {
+          return _dataItemManipulator2(field, value, row);
         }
       });
     }
@@ -606,30 +608,30 @@ function (_Component) {
 }(_react.Component);
 
 DynamicDataTable.propTypes = {
-  rows: _propTypes.default.array,
-  fieldsToExclude: _propTypes.default.array,
-  fieldMap: _propTypes.default.object,
-  fieldOrder: _propTypes.default.array,
-  currentPage: _propTypes.default.number,
-  totalPages: _propTypes.default.number,
-  orderByField: _propTypes.default.string,
-  orderByDirection: _propTypes.default.oneOf(['asc', 'desc']),
-  renderCheckboxes: _propTypes.default.bool,
-  actions: _propTypes.default.array,
-  loading: _propTypes.default.bool,
-  loadingMessage: _propTypes.default.string,
-  loadingIndicator: _propTypes.default.element,
-  loadingComponent: _propTypes.default.element,
-  errorMessage: _propTypes.default.string,
-  noDataMessage: _propTypes.default.string,
-  noDataComponent: _propTypes.default.element,
-  dataItemManipulator: _propTypes.default.func,
-  buttons: _propTypes.default.oneOfType([_propTypes.default.array, _propTypes.default.func]),
-  rowRenderer: _propTypes.default.func,
-  onClick: _propTypes.default.func,
-  hoverable: _propTypes.default.bool,
-  allowOrderingBy: _propTypes.default.array,
-  disallowOrderingBy: _propTypes.default.array
+  rows: _propTypes["default"].array,
+  fieldsToExclude: _propTypes["default"].array,
+  fieldMap: _propTypes["default"].object,
+  fieldOrder: _propTypes["default"].array,
+  currentPage: _propTypes["default"].number,
+  totalPages: _propTypes["default"].number,
+  orderByField: _propTypes["default"].string,
+  orderByDirection: _propTypes["default"].oneOf(['asc', 'desc']),
+  renderCheckboxes: _propTypes["default"].bool,
+  actions: _propTypes["default"].array,
+  loading: _propTypes["default"].bool,
+  loadingMessage: _propTypes["default"].string,
+  loadingIndicator: _propTypes["default"].element,
+  loadingComponent: _propTypes["default"].element,
+  errorMessage: _propTypes["default"].string,
+  noDataMessage: _propTypes["default"].string,
+  noDataComponent: _propTypes["default"].element,
+  dataItemManipulator: _propTypes["default"].func,
+  buttons: _propTypes["default"].oneOfType([_propTypes["default"].array, _propTypes["default"].func]),
+  rowRenderer: _propTypes["default"].func,
+  onClick: _propTypes["default"].func,
+  hoverable: _propTypes["default"].bool,
+  allowOrderingBy: _propTypes["default"].array,
+  disallowOrderingBy: _propTypes["default"].array
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -665,4 +667,4 @@ DynamicDataTable.defaultProps = {
   disallowOrderingBy: []
 };
 var _default = DynamicDataTable;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,28 +8,28 @@ Object.defineProperty(exports, "__esModule", {
 Object.defineProperty(exports, "DynamicDataTable", {
   enumerable: true,
   get: function get() {
-    return _DynamicDataTable.default;
+    return _DynamicDataTable["default"];
   }
 });
 Object.defineProperty(exports, "AjaxDynamicDataTable", {
   enumerable: true,
   get: function get() {
-    return _AjaxDynamicDataTable.default;
+    return _AjaxDynamicDataTable["default"];
   }
 });
 Object.defineProperty(exports, "DataRow", {
   enumerable: true,
   get: function get() {
-    return _DataRow.default;
+    return _DataRow["default"];
   }
 });
 Object.defineProperty(exports, "Pagination", {
   enumerable: true,
   get: function get() {
-    return _Pagination.default;
+    return _Pagination["default"];
   }
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _DynamicDataTable = _interopRequireDefault(require("./DynamicDataTable"));
 
@@ -39,7 +39,7 @@ var _DataRow = _interopRequireDefault(require("./Components/DataRow"));
 
 var _Pagination = _interopRequireDefault(require("./Components/Pagination"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-var _default = _DynamicDataTable.default;
-exports.default = _default;
+var _default = _DynamicDataTable["default"];
+exports["default"] = _default;

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -48,7 +48,7 @@ class DataRow extends Component {
     renderCell(field, row) {
         let value = row[field.name];
 
-        value = this.props.dataItemManipulator(field.name, value);
+        value = this.props.dataItemManipulator(field.name, value, row);
 
         if (typeof value === 'object' || typeof value === 'array') {
             value = JSON.stringify(value);

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -31,7 +31,7 @@ class DynamicDataTable extends Component {
                 renderCheckboxes={renderCheckboxes}
                 checkboxIsChecked={checkboxIsChecked}
                 checkboxChange={onCheckboxChange}
-                dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
+                dataItemManipulator={(field, value, row) => dataItemManipulator(field, value, row)}
             />
         );
     }
@@ -229,7 +229,7 @@ class DynamicDataTable extends Component {
             renderCheckboxes,
             key: row.id,
             fields: this.getFields(),
-            dataItemManipulator: (field, value) => dataItemManipulator(field, value),
+            dataItemManipulator: (field, value, row) => dataItemManipulator(field, value, row),
             checkboxIsChecked: (value) => this.checkboxIsChecked(value),
             onCheckboxChange: (e) => this.checkboxChange(e),
         });


### PR DESCRIPTION
It is sometimes useful to have the ability to access the specific row data when manipulating one particular field via the `dataItemManipulator` callback.

This PR simply passes in the row data as the callbacks' previously unused third parameter.

There should be no backward incompatibilities or regressions.