### PR TITLE
Allow for rendering of React Components within the dataItemManipulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,60 @@ An example of show to use bulk actions is shown below.
 />
 ```
 
+### Data Item Manipulation
+
+If you wish to alter row data prior to it being rendered, you may use the `dataItemManipulator` prop available on the 
+`DynamicDataTable`. This prop expects a `function` which will be passed two parameters, the `field`, and the `value`. 
+This function will be called once for every cell that is to be rendered.
+
+```JSX
+<DynamicDataTable
+    dataItemManipulator={(field, value) => {
+        switch(field) {
+            case 'id':
+                return 'ID:' + value;
+            case 'reference':
+                return value.toUpperCase();
+        }
+        
+        return value;
+    }}
+/>
+```
+
+It is also possible to render React components directly, by returning them from this function.
+
+```JSX
+<DynamicDataTable
+    dataItemManipulator={(field, value) => {
+        switch(field) {
+            case 'reference':
+                return <ExampleComponent exampleProp={value} />;
+        }
+        
+        return value;
+    }}
+/>
+```
+
+If you wish, you can dangerously render HTML directly by returning a string from the `dataItemManipulator`, you will 
+however need to explicitly specify which fields this should be enabled for. This is done by using the 
+`dangerouslyRenderFields` prop.
+
+ ```JSX
+ <DynamicDataTable
+     dangerouslyRenderFields={['check']}
+     dataItemManipulator={(field, value) => {
+         switch(field) {
+             case 'check':
+                 return "<i class='fa fa-check'></i>";
+         }
+         
+         return value;
+     }}
+ />
+ ```
+
 ### Loading message & indicator
 
 By default, the React Dynamic Data Table will not show indication that it is

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -3,19 +3,21 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
-
-require("core-js/modules/es6.symbol");
 
 require("core-js/modules/es6.array.for-each");
 
 require("core-js/modules/es6.array.filter");
 
+require("core-js/modules/es6.symbol");
+
 require("core-js/modules/web.dom.iterable");
 
 require("core-js/modules/es6.array.iterator");
+
+require("core-js/modules/es6.object.to-string");
 
 require("core-js/modules/es6.object.keys");
 
@@ -35,9 +37,9 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _DynamicDataTable = _interopRequireDefault(require("./DynamicDataTable"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -57,11 +59,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var AjaxDynamicDataTable =
 /*#__PURE__*/
@@ -84,9 +86,9 @@ function (_Component) {
       orderByDirection: defaultOrderByDirection,
       loading: false
     };
-    _this.reload = _this.reload.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.changePage = _this.changePage.bind(_assertThisInitialized(_assertThisInitialized(_this)));
-    _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.reload = _this.reload.bind(_assertThisInitialized(_this));
+    _this.changePage = _this.changePage.bind(_assertThisInitialized(_this));
+    _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -112,7 +114,7 @@ function (_Component) {
           orderByField = _this$state.orderByField,
           orderByDirection = _this$state.orderByDirection,
           loading = _this$state.loading;
-      return _react.default.createElement(_DynamicDataTable.default, _extends({
+      return _react["default"].createElement(_DynamicDataTable["default"], _extends({
         rows: rows,
         currentPage: currentPage,
         totalPages: totalPages,
@@ -200,11 +202,11 @@ AjaxDynamicDataTable.defaultProps = {
   defaultOrderByDirection: null
 };
 AjaxDynamicDataTable.propTypes = {
-  apiUrl: _propTypes.default.string,
-  onLoad: _propTypes.default.func,
-  params: _propTypes.default.object,
-  defaultOrderByField: _propTypes.default.string,
-  defaultOrderByDirection: _propTypes.default.string
+  apiUrl: _propTypes["default"].string,
+  onLoad: _propTypes["default"].func,
+  params: _propTypes["default"].object,
+  defaultOrderByField: _propTypes["default"].string,
+  defaultOrderByDirection: _propTypes["default"].string
 };
 var _default = AjaxDynamicDataTable;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -19,13 +19,17 @@ require("core-js/modules/es6.function.name");
 
 require("core-js/modules/es6.array.map");
 
+require("core-js/modules/es7.array.includes");
+
+require("core-js/modules/es6.string.includes");
+
 var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -57,6 +61,12 @@ function (_Component) {
   }
 
   _createClass(DataRow, [{
+    key: "shouldDangerouslyRenderField",
+    value: function shouldDangerouslyRenderField(field) {
+      var dangerouslyRenderFields = this.props.dangerouslyRenderFields;
+      return dangerouslyRenderFields.includes(field);
+    }
+  }, {
     key: "render",
     value: function render() {
       var _this = this;
@@ -66,7 +76,7 @@ function (_Component) {
           fields = _this$props.fields,
           _onClick = _this$props.onClick,
           _onContextMenu = _this$props.onContextMenu;
-      return _react.default.createElement("tr", {
+      return _react["default"].createElement("tr", {
         onClick: function onClick() {
           return _onClick(row);
         },
@@ -90,9 +100,9 @@ function (_Component) {
         return;
       }
 
-      var checkbox = _react.default.createElement("div", {
+      var checkbox = _react["default"].createElement("div", {
         className: "form-check"
-      }, _react.default.createElement("input", {
+      }, _react["default"].createElement("input", {
         type: "checkbox",
         checked: this.props.checkboxIsChecked(row),
         onChange: function onChange(event) {
@@ -106,20 +116,36 @@ function (_Component) {
         }
       }));
 
-      return _react.default.createElement("td", null, checkbox);
+      return _react["default"].createElement("td", null, checkbox);
     }
   }, {
     key: "renderCell",
     value: function renderCell(field, row) {
       var value = row[field.name];
       value = this.props.dataItemManipulator(field.name, value);
+      var key = "".concat(row.id, "_").concat(field.name);
+
+      if (_react["default"].isValidElement(value)) {
+        return _react["default"].createElement("td", {
+          key: key
+        }, value);
+      }
+
+      if (this.shouldDangerouslyRenderField(field.name)) {
+        return _react["default"].createElement("td", {
+          key: key,
+          dangerouslySetInnerHTML: {
+            __html: value
+          }
+        });
+      }
 
       if (_typeof(value) === 'object' || typeof value === 'array') {
         value = JSON.stringify(value);
       }
 
-      return _react.default.createElement("td", {
-        key: "".concat(row.id, "_").concat(field.name)
+      return _react["default"].createElement("td", {
+        key: key
       }, value);
     }
   }, {
@@ -134,33 +160,33 @@ function (_Component) {
       }
 
       if (!buttons.length) {
-        return _react.default.createElement("td", null);
+        return _react["default"].createElement("td", null);
       }
 
       var button = buttons[0];
 
       if (buttons.length === 1) {
-        return _react.default.createElement("td", {
+        return _react["default"].createElement("td", {
           className: "rddt-action-cell"
         }, this.renderFirstButton(button, row));
       }
 
-      return _react.default.createElement("td", {
+      return _react["default"].createElement("td", {
         className: "rddt-action-cell"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "btn-group",
         onClick: function onClick(e) {
           return e.stopPropagation();
         }
-      }, this.renderFirstButton(button, row), _react.default.createElement("button", {
+      }, this.renderFirstButton(button, row), _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary dropdown-toggle dropdown-toggle-split",
         "data-toggle": "dropdown",
         "aria-haspopup": "true",
         "aria-expanded": "false"
-      }, _react.default.createElement("span", {
+      }, _react["default"].createElement("span", {
         className: "sr-only"
-      }, "Toggle Dropdown")), _react.default.createElement("div", {
+      }, "Toggle Dropdown")), _react["default"].createElement("div", {
         className: "dropdown-menu",
         "aria-labelledby": "dropdownMenuButton"
       }, buttons.map(function (button, index) {
@@ -174,7 +200,7 @@ function (_Component) {
         return button.render(row);
       }
 
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary",
         onClick: function onClick() {
@@ -190,7 +216,7 @@ function (_Component) {
       }
 
       if (typeof button.render === 'function') {
-        _react.default.createElement("div", {
+        _react["default"].createElement("div", {
           style: {
             cursor: 'pointer'
           },
@@ -199,7 +225,7 @@ function (_Component) {
         }, button.render(row));
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         style: {
           cursor: 'pointer'
         },
@@ -222,17 +248,19 @@ function (_Component) {
 
 DataRow.defaultProps = {
   onClick: DataRow.noop,
-  onContextMenu: DataRow.noop
+  onContextMenu: DataRow.noop,
+  dangerouslyRenderFields: []
 };
 DataRow.propTypes = {
-  row: _propTypes.default.object,
-  buttons: _propTypes.default.oneOfType([_propTypes.default.array, _propTypes.default.func]),
-  checkboxIsChecked: _propTypes.default.func,
-  checkboxChange: _propTypes.default.func,
-  dataItemManipulator: _propTypes.default.func,
-  renderCheckboxes: _propTypes.default.bool,
-  onClick: _propTypes.default.func,
-  onContextMenu: _propTypes.default.func
+  row: _propTypes["default"].object,
+  buttons: _propTypes["default"].oneOfType([_propTypes["default"].array, _propTypes["default"].func]),
+  checkboxIsChecked: _propTypes["default"].func,
+  checkboxChange: _propTypes["default"].func,
+  dataItemManipulator: _propTypes["default"].func,
+  renderCheckboxes: _propTypes["default"].bool,
+  onClick: _propTypes["default"].func,
+  onContextMenu: _propTypes["default"].func,
+  dangerouslyRenderFields: _propTypes["default"].array
 };
 var _default = DataRow;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/Components/Pagination.js
+++ b/dist/Components/Pagination.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -19,9 +19,9 @@ var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -67,10 +67,10 @@ function (_Component) {
       }
 
       var _loop = function _loop(i) {
-        pageLinks.push(_react.default.createElement("li", {
+        pageLinks.push(_react["default"].createElement("li", {
           key: "page_".concat(i),
           className: "page-item ".concat(currentPage === i ? 'active' : '')
-        }, _react.default.createElement("button", {
+        }, _react["default"].createElement("button", {
           type: "button",
           className: "page-link",
           onClick: function onClick() {
@@ -83,21 +83,21 @@ function (_Component) {
         _loop(i);
       }
 
-      return _react.default.createElement("nav", {
+      return _react["default"].createElement("nav", {
         "aria-label": "Page navigation"
-      }, _react.default.createElement("ul", {
+      }, _react["default"].createElement("ul", {
         className: "pagination"
-      }, _react.default.createElement("li", {
+      }, _react["default"].createElement("li", {
         className: "page-item ".concat(currentPage <= 1 ? 'disabled' : '')
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "page-link",
         onClick: function onClick() {
           return _this.previousPage();
         }
-      }, "Previous")), pageLinks, _react.default.createElement("li", {
+      }, "Previous")), pageLinks, _react["default"].createElement("li", {
         className: "page-item ".concat(currentPage >= totalPages ? 'disabled' : '')
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "page-link",
         onClick: function onClick() {
@@ -130,9 +130,9 @@ function (_Component) {
 }(_react.Component);
 
 Pagination.propTypes = {
-  currentPage: _propTypes.default.number,
-  totalPages: _propTypes.default.number,
-  changePage: _propTypes.default.func
+  currentPage: _propTypes["default"].number,
+  totalPages: _propTypes["default"].number,
+  changePage: _propTypes["default"].func
 };
 var _default = Pagination;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -43,6 +43,8 @@ require("core-js/modules/web.dom.iterable");
 
 require("core-js/modules/es6.array.iterator");
 
+require("core-js/modules/es6.object.to-string");
+
 require("core-js/modules/es6.object.keys");
 
 require("core-js/modules/es6.function.bind");
@@ -57,9 +59,9 @@ var _DataRow = _interopRequireDefault(require("./Components/DataRow"));
 
 var _Pagination = _interopRequireDefault(require("./Components/Pagination"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -73,11 +75,11 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 var DynamicDataTable =
 /*#__PURE__*/
@@ -93,7 +95,7 @@ function (_Component) {
     _this.state = {
       checkedRows: []
     };
-    _this.className = _this.className.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    _this.className = _this.className.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -112,7 +114,7 @@ function (_Component) {
       var _this$props = this.props,
           onClick = _this$props.onClick,
           hoverable = _this$props.hoverable;
-      return (0, _classnames.default)(['table', 'table-striped', {
+      return (0, _classnames["default"])(['table', 'table-striped', {
         'table-hover': onClick !== DynamicDataTable.noop || hoverable
       }]);
     }
@@ -268,13 +270,13 @@ function (_Component) {
         return this.renderEmptyTable();
       }
 
-      return _react.default.createElement("div", null, _react.default.createElement("div", {
+      return _react["default"].createElement("div", null, _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: this.className()
-      }, _react.default.createElement("thead", null, _react.default.createElement("tr", null, this.renderCheckboxCell('all'), fields.map(function (field) {
+      }, _react["default"].createElement("thead", null, _react["default"].createElement("tr", null, this.renderCheckboxCell('all'), fields.map(function (field) {
         return _this2.renderHeader(field);
-      }), this.renderActionsCell())), _react.default.createElement("tbody", null, rows.map(function (row) {
+      }), this.renderActionsCell())), _react["default"].createElement("tbody", null, rows.map(function (row) {
         return _this2.renderRow(row);
       })))), this.renderPagination());
     }
@@ -288,7 +290,8 @@ function (_Component) {
           buttons = _this$props4.buttons,
           renderCheckboxes = _this$props4.renderCheckboxes,
           _dataItemManipulator = _this$props4.dataItemManipulator,
-          rowRenderer = _this$props4.rowRenderer;
+          rowRenderer = _this$props4.rowRenderer,
+          dangerouslyRenderFields = _this$props4.dangerouslyRenderFields;
       return rowRenderer({
         row: row,
         onClick: onClick,
@@ -304,7 +307,8 @@ function (_Component) {
         },
         onCheckboxChange: function onCheckboxChange(e) {
           return _this3.checkboxChange(e);
-        }
+        },
+        dangerouslyRenderFields: dangerouslyRenderFields
       });
     }
   }, {
@@ -329,7 +333,7 @@ function (_Component) {
         return _this4.changeOrder(field);
       } : function () {};
       var cursor = changeOrder && canOrderBy ? 'pointer' : 'default';
-      return _react.default.createElement("th", {
+      return _react["default"].createElement("th", {
         style: {
           cursor: cursor
         },
@@ -346,14 +350,14 @@ function (_Component) {
       var state = this.state;
 
       if (!props.renderCheckboxes || !this.props.actions.length) {
-        return _react.default.createElement("th", null);
+        return _react["default"].createElement("th", null);
       }
 
-      return _react.default.createElement("th", {
+      return _react["default"].createElement("th", {
         className: "rddt-action-cell"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "dropdown"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         className: "btn btn-secondary dropdown-toggle",
         type: "button",
         id: "dropdownMenuButton",
@@ -361,7 +365,7 @@ function (_Component) {
         "aria-haspopup": "true",
         "aria-expanded": "false",
         disabled: !state.checkedRows.length
-      }, "Actions"), _react.default.createElement("div", {
+      }, "Actions"), _react["default"].createElement("div", {
         className: "dropdown-menu",
         "aria-labelledby": "dropdownMenuButton"
       }, this.props.actions.map(function (action) {
@@ -373,7 +377,7 @@ function (_Component) {
     value: function renderActionButton(action) {
       var _this6 = this;
 
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         key: "action_".concat(action.name),
         type: "button",
         className: "dropdown-item",
@@ -411,9 +415,9 @@ function (_Component) {
         return;
       }
 
-      var checkbox = _react.default.createElement("div", {
+      var checkbox = _react["default"].createElement("div", {
         className: "form-check"
-      }, _react.default.createElement("input", {
+      }, _react["default"].createElement("input", {
         type: "checkbox",
         value: value,
         checked: this.checkboxIsChecked(value),
@@ -426,10 +430,10 @@ function (_Component) {
       }));
 
       if (value === 'all') {
-        return _react.default.createElement("th", null, checkbox);
+        return _react["default"].createElement("th", null, checkbox);
       }
 
-      return _react.default.createElement("td", null, checkbox);
+      return _react["default"].createElement("td", null, checkbox);
     }
   }, {
     key: "checkboxIsChecked",
@@ -520,22 +524,22 @@ function (_Component) {
         return loadingComponent;
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: "table table-striped"
-      }, _react.default.createElement("tbody", null, _react.default.createElement("tr", null, _react.default.createElement("td", {
+      }, _react["default"].createElement("tbody", null, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
         className: "text-center"
-      }, !!loadingIndicator && _react.default.createElement("div", null, loadingIndicator), !!loadingMessage && _react.default.createElement("div", null, loadingMessage))))));
+      }, !!loadingIndicator && _react["default"].createElement("div", null, loadingIndicator), !!loadingMessage && _react["default"].createElement("div", null, loadingMessage))))));
     }
   }, {
     key: "renderErrorTable",
     value: function renderErrorTable() {
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: "table table-striped"
-      }, _react.default.createElement("tbody", null, _react.default.createElement("tr", null, _react.default.createElement("td", {
+      }, _react["default"].createElement("tbody", null, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
         className: "text-center"
       }, this.props.errorMessage)))));
     }
@@ -546,15 +550,15 @@ function (_Component) {
           noDataMessage = _this$props7.noDataMessage,
           noDataComponent = _this$props7.noDataComponent;
 
-      if (_react.default.isValidElement(noDataComponent)) {
+      if (_react["default"].isValidElement(noDataComponent)) {
         return noDataComponent;
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "table-responsive"
-      }, _react.default.createElement("table", {
+      }, _react["default"].createElement("table", {
         className: "table table-striped"
-      }, _react.default.createElement("tbody", null, _react.default.createElement("tr", null, _react.default.createElement("td", {
+      }, _react["default"].createElement("tbody", null, _react["default"].createElement("tr", null, _react["default"].createElement("td", {
         className: "text-center"
       }, noDataMessage)))));
     }
@@ -562,7 +566,7 @@ function (_Component) {
     key: "renderPagination",
     value: function renderPagination() {
       var props = this.props;
-      return _react.default.createElement(_Pagination.default, {
+      return _react["default"].createElement(_Pagination["default"], {
         currentPage: props.currentPage,
         totalPages: props.totalPages,
         changePage: function changePage(page) {
@@ -585,8 +589,9 @@ function (_Component) {
           renderCheckboxes = _ref2.renderCheckboxes,
           checkboxIsChecked = _ref2.checkboxIsChecked,
           onCheckboxChange = _ref2.onCheckboxChange,
-          _dataItemManipulator2 = _ref2.dataItemManipulator;
-      return _react.default.createElement(_DataRow.default, {
+          _dataItemManipulator2 = _ref2.dataItemManipulator,
+          dangerouslyRenderFields = _ref2.dangerouslyRenderFields;
+      return _react["default"].createElement(_DataRow["default"], {
         key: row.id,
         row: row,
         onClick: onClick,
@@ -597,7 +602,8 @@ function (_Component) {
         checkboxChange: onCheckboxChange,
         dataItemManipulator: function dataItemManipulator(field, value) {
           return _dataItemManipulator2(field, value);
-        }
+        },
+        dangerouslyRenderFields: dangerouslyRenderFields
       });
     }
   }]);
@@ -606,30 +612,31 @@ function (_Component) {
 }(_react.Component);
 
 DynamicDataTable.propTypes = {
-  rows: _propTypes.default.array,
-  fieldsToExclude: _propTypes.default.array,
-  fieldMap: _propTypes.default.object,
-  fieldOrder: _propTypes.default.array,
-  currentPage: _propTypes.default.number,
-  totalPages: _propTypes.default.number,
-  orderByField: _propTypes.default.string,
-  orderByDirection: _propTypes.default.oneOf(['asc', 'desc']),
-  renderCheckboxes: _propTypes.default.bool,
-  actions: _propTypes.default.array,
-  loading: _propTypes.default.bool,
-  loadingMessage: _propTypes.default.string,
-  loadingIndicator: _propTypes.default.element,
-  loadingComponent: _propTypes.default.element,
-  errorMessage: _propTypes.default.string,
-  noDataMessage: _propTypes.default.string,
-  noDataComponent: _propTypes.default.element,
-  dataItemManipulator: _propTypes.default.func,
-  buttons: _propTypes.default.oneOfType([_propTypes.default.array, _propTypes.default.func]),
-  rowRenderer: _propTypes.default.func,
-  onClick: _propTypes.default.func,
-  hoverable: _propTypes.default.bool,
-  allowOrderingBy: _propTypes.default.array,
-  disallowOrderingBy: _propTypes.default.array
+  rows: _propTypes["default"].array,
+  fieldsToExclude: _propTypes["default"].array,
+  fieldMap: _propTypes["default"].object,
+  fieldOrder: _propTypes["default"].array,
+  currentPage: _propTypes["default"].number,
+  totalPages: _propTypes["default"].number,
+  orderByField: _propTypes["default"].string,
+  orderByDirection: _propTypes["default"].oneOf(['asc', 'desc']),
+  renderCheckboxes: _propTypes["default"].bool,
+  actions: _propTypes["default"].array,
+  loading: _propTypes["default"].bool,
+  loadingMessage: _propTypes["default"].string,
+  loadingIndicator: _propTypes["default"].element,
+  loadingComponent: _propTypes["default"].element,
+  errorMessage: _propTypes["default"].string,
+  noDataMessage: _propTypes["default"].string,
+  noDataComponent: _propTypes["default"].element,
+  dataItemManipulator: _propTypes["default"].func,
+  buttons: _propTypes["default"].oneOfType([_propTypes["default"].array, _propTypes["default"].func]),
+  rowRenderer: _propTypes["default"].func,
+  onClick: _propTypes["default"].func,
+  hoverable: _propTypes["default"].bool,
+  allowOrderingBy: _propTypes["default"].array,
+  disallowOrderingBy: _propTypes["default"].array,
+  dangerouslyRenderFields: _propTypes["default"].array
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -662,7 +669,8 @@ DynamicDataTable.defaultProps = {
   onClick: DynamicDataTable.noop,
   hoverable: false,
   allowOrderingBy: [],
-  disallowOrderingBy: []
+  disallowOrderingBy: [],
+  dangerouslyRenderFields: []
 };
 var _default = DynamicDataTable;
-exports.default = _default;
+exports["default"] = _default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,28 +8,28 @@ Object.defineProperty(exports, "__esModule", {
 Object.defineProperty(exports, "DynamicDataTable", {
   enumerable: true,
   get: function get() {
-    return _DynamicDataTable.default;
+    return _DynamicDataTable["default"];
   }
 });
 Object.defineProperty(exports, "AjaxDynamicDataTable", {
   enumerable: true,
   get: function get() {
-    return _AjaxDynamicDataTable.default;
+    return _AjaxDynamicDataTable["default"];
   }
 });
 Object.defineProperty(exports, "DataRow", {
   enumerable: true,
   get: function get() {
-    return _DataRow.default;
+    return _DataRow["default"];
   }
 });
 Object.defineProperty(exports, "Pagination", {
   enumerable: true,
   get: function get() {
-    return _Pagination.default;
+    return _Pagination["default"];
   }
 });
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _DynamicDataTable = _interopRequireDefault(require("./DynamicDataTable"));
 
@@ -39,7 +39,7 @@ var _DataRow = _interopRequireDefault(require("./Components/DataRow"));
 
 var _Pagination = _interopRequireDefault(require("./Components/Pagination"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-var _default = _DynamicDataTable.default;
-exports.default = _default;
+var _default = _DynamicDataTable["default"];
+exports["default"] = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -7,6 +7,12 @@ class DataRow extends Component {
         return null;
     }
 
+    shouldDangerouslyRenderField(field) {
+        const { dangerouslyRenderFields } = this.props;
+        
+        return dangerouslyRenderFields.includes(field);
+    }
+    
     render() {
         const { row, fields, onClick, onContextMenu } = this.props;
 
@@ -50,12 +56,26 @@ class DataRow extends Component {
 
         value = this.props.dataItemManipulator(field.name, value);
 
+        const key = `${row.id}_${field.name}`;
+
+        if (React.isValidElement(value)) {
+            return (
+                <td key={key}>{value}</td>
+            );
+        }
+
+        if (this.shouldDangerouslyRenderField(field.name)) {
+            return (
+                <td key={key} dangerouslySetInnerHTML={{__html: value}}/>
+            );
+        }
+
         if (typeof value === 'object' || typeof value === 'array') {
             value = JSON.stringify(value);
         }
 
         return (
-            <td key={`${row.id}_${field.name}`}>{ value }</td>
+            <td key={key}>{ value }</td>
         );
     }
 
@@ -146,6 +166,7 @@ class DataRow extends Component {
 DataRow.defaultProps = {
     onClick: DataRow.noop,
     onContextMenu: DataRow.noop,
+    dangerouslyRenderFields: [],
 };
 
 DataRow.propTypes = {
@@ -159,6 +180,7 @@ DataRow.propTypes = {
     renderCheckboxes: PropTypes.bool,
     onClick: PropTypes.func,
     onContextMenu: PropTypes.func,
+    dangerouslyRenderFields: PropTypes.array
 };
 
 export default DataRow;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -20,7 +20,7 @@ class DynamicDataTable extends Component {
         return null;
     }
 
-    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator }) {
+    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator, dangerouslyRenderFields }) {
         return (
             <DataRow
                 key={row.id}
@@ -32,6 +32,7 @@ class DynamicDataTable extends Component {
                 checkboxIsChecked={checkboxIsChecked}
                 checkboxChange={onCheckboxChange}
                 dataItemManipulator={(field, value) => dataItemManipulator(field, value)}
+                dangerouslyRenderFields={dangerouslyRenderFields}
             />
         );
     }
@@ -220,7 +221,9 @@ class DynamicDataTable extends Component {
     }
 
     renderRow(row) {
-        const { onClick, buttons, renderCheckboxes, dataItemManipulator, rowRenderer } = this.props;
+        const {
+            onClick, buttons, renderCheckboxes, dataItemManipulator, rowRenderer, dangerouslyRenderFields
+        } = this.props;
 
         return rowRenderer({
             row,
@@ -232,6 +235,7 @@ class DynamicDataTable extends Component {
             dataItemManipulator: (field, value) => dataItemManipulator(field, value),
             checkboxIsChecked: (value) => this.checkboxIsChecked(value),
             onCheckboxChange: (e) => this.checkboxChange(e),
+            dangerouslyRenderFields,
         });
     }
 
@@ -538,6 +542,7 @@ DynamicDataTable.propTypes = {
     hoverable: PropTypes.bool,
     allowOrderingBy: PropTypes.array,
     disallowOrderingBy: PropTypes.array,
+    dangerouslyRenderFields: PropTypes.array,
 };
 
 DynamicDataTable.defaultProps = {
@@ -572,6 +577,7 @@ DynamicDataTable.defaultProps = {
     hoverable: false,
     allowOrderingBy: [],
     disallowOrderingBy: [],
+    dangerouslyRenderFields: [],
 };
 
 export default DynamicDataTable;


### PR DESCRIPTION
In addition, allows for the rendering of HTML strings by utilising the `dangerouslyRenderFields` prop. 

Explanation of functionality can be found within the `README.md` as part of this PR.