### PR TITLE
Feature: Make AjaxDataTable initially search for a global axios instance

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -136,14 +136,13 @@ function (_Component) {
     value: function loadPage(page) {
       var _this2 = this;
 
-      var axios = require('axios');
-
       var _this$state2 = this.state,
           orderByField = _this$state2.orderByField,
           orderByDirection = _this$state2.orderByDirection;
       var _this$props = this.props,
           onLoad = _this$props.onLoad,
-          params = _this$props.params;
+          params = _this$props.params,
+          axios = _this$props.axios;
       this.setState({
         loading: true
       }, function () {
@@ -199,14 +198,16 @@ AjaxDynamicDataTable.defaultProps = {
   },
   params: {},
   defaultOrderByField: null,
-  defaultOrderByDirection: null
+  defaultOrderByDirection: null,
+  axios: window.axios || require('axios')
 };
 AjaxDynamicDataTable.propTypes = {
   apiUrl: _propTypes["default"].string,
   onLoad: _propTypes["default"].func,
   params: _propTypes["default"].object,
   defaultOrderByField: _propTypes["default"].string,
-  defaultOrderByDirection: _propTypes["default"].string
+  defaultOrderByDirection: _propTypes["default"].string,
+  axios: _propTypes["default"].any
 };
 var _default = AjaxDynamicDataTable;
 exports["default"] = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -56,10 +56,8 @@ class AjaxDynamicDataTable extends Component {
     }
 
     loadPage(page) {
-
-        const axios = require('axios');
         const {orderByField, orderByDirection} = this.state;
-        const {onLoad, params} = this.props;
+        const {onLoad, params, axios} = this.props;
 
         this.setState(
             { loading: true },
@@ -99,6 +97,7 @@ AjaxDynamicDataTable.defaultProps = {
     params: {},
     defaultOrderByField: null,
     defaultOrderByDirection: null,
+    axios: window.axios || require('axios'),
 };
 
 AjaxDynamicDataTable.propTypes = {
@@ -107,6 +106,7 @@ AjaxDynamicDataTable.propTypes = {
     params: PropTypes.object,
     defaultOrderByField: PropTypes.string,
     defaultOrderByDirection: PropTypes.string,
+    axios: PropTypes.any,
 };
 
 export default AjaxDynamicDataTable;


### PR DESCRIPTION
If not found, falls back to previous behaviour of requiring one.
Also allows the passing in of an axios instance to use via the `axios`
prop.