### PR TITLE
Pass event object to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ For implementation details regarding these properties, see the other relevant ar
 
 ### Clickable rows
 
-Clickable rows allows an `onClick` prop to be passed which will return an event object along with
+Clickable rows allows an `onClick` prop to be passed. This should be a callable, that will be passed an event object along with
 an instance of the row that is clicked. It also adds the bootstrap `table-hover` class onto the table.
 
 ```JSX

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ an instance of the row that is clicked. It also adds the bootstrap `table-hover`
 ```JSX
 <DynamicDataTable
     rows={this.state.users}
-    onClick={row => console.warn(event, row.name)}
+    onClick={(event, row) => console.warn(event, row.name)}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -271,9 +271,8 @@ and `callback`.
 
 The `name` is string, such as 'View', 'Edit', 'Delete', etc.
 
-The `callback` is a callable with a single argument. The argument will
-contain an object representing the data of the row on which the button is 
-situated. 
+The `callback` is a callable with a two arguments. The first is the event object
+for the button clicked and the second is an object representing the current row.
 
 An example of setting custom row buttons is shown below.
 
@@ -283,13 +282,13 @@ An example of setting custom row buttons is shown below.
     buttons={[
         {
             name: 'Edit',
-            callback: (user) => {
+            callback: (event, user) => {
                 // Show edit user view...
             }
         },
         {
             name: 'Delete',
-            callback: (user) => {
+            callback: (event, user) => {
                 // Delete user...
             }
         }
@@ -359,13 +358,13 @@ For implementation details regarding these properties, see the other relevant ar
 
 ### Clickable rows
 
-Clickable rows allows an `onClick` prop to be passed which will return an instance of
-the row that is clicked. It also adds the bootstrap `table-hover` class onto the table.
+Clickable rows allows an `onClick` prop to be passed which will return an event object along with
+an instance of the row that is clicked. It also adds the bootstrap `table-hover` class onto the table.
 
 ```JSX
 <DynamicDataTable
     rows={this.state.users}
-    onClick={row => console.warn(row.name)}
+    onClick={row => console.warn(event, row.name)}
 />
 ```
 

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -7,6 +7,10 @@ exports["default"] = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
+require("core-js/modules/es7.object.get-own-property-descriptors");
+
+require("core-js/modules/es6.object.define-properties");
+
 require("core-js/modules/es6.array.for-each");
 
 require("core-js/modules/es6.array.filter");
@@ -43,7 +47,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { if (i % 2) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } else { Object.defineProperties(target, Object.getOwnPropertyDescriptors(arguments[i])); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -77,8 +77,8 @@ function (_Component) {
           _onClick = _this$props.onClick,
           _onContextMenu = _this$props.onContextMenu;
       return _react["default"].createElement("tr", {
-        onClick: function onClick() {
-          return _onClick(row);
+        onClick: function onClick(e) {
+          return _onClick(e, row);
         },
         onContextMenu: function onContextMenu(e) {
           return _onContextMenu(e, row);
@@ -105,11 +105,8 @@ function (_Component) {
       }, _react["default"].createElement("input", {
         type: "checkbox",
         checked: this.props.checkboxIsChecked(row),
-        onChange: function onChange(event) {
-          return _this2.props.checkboxChange({
-            event: event,
-            row: row
-          });
+        onChange: function onChange(e) {
+          return _this2.props.checkboxChange(e, row);
         },
         onClick: function onClick(e) {
           return e.stopPropagation();
@@ -203,8 +200,8 @@ function (_Component) {
       return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary",
-        onClick: function onClick() {
-          button.callback(row);
+        onClick: function onClick(e) {
+          return button.callback(e, row);
         }
       }, button.name);
     }
@@ -231,8 +228,8 @@ function (_Component) {
         },
         key: "button_".concat(button.name),
         className: "dropdown-item",
-        onClick: function onClick() {
-          button.callback(row);
+        onClick: function onClick(e) {
+          return button.callback(e, row);
         }
       }, button.name);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -18,7 +18,7 @@ class DataRow extends Component {
 
         return (
             <tr
-                onClick={() => onClick(row)}
+                onClick={e => onClick(e, row)}
                 onContextMenu={e => onContextMenu(e, row)}
             >
                 { this.renderCheckboxCell() }
@@ -40,7 +40,7 @@ class DataRow extends Component {
                 <input
                     type="checkbox"
                     checked={this.props.checkboxIsChecked(row)}
-                    onChange={event => this.props.checkboxChange({ event, row })}
+                    onChange={e => this.props.checkboxChange(e, row)}
                     onClick={e => e.stopPropagation()}
                 />
             </div>
@@ -128,7 +128,7 @@ class DataRow extends Component {
             <button
                 type="button"
                 className="btn btn-primary"
-                onClick={() => { button.callback(row) }}
+                onClick={e => button.callback(e, row)}
             >
                 {button.name}
             </button>
@@ -155,7 +155,7 @@ class DataRow extends Component {
                 style={{cursor: 'pointer'}}
                 key={`button_${button.name}`}
                 className="dropdown-item"
-                onClick={() => { button.callback(row) }}>
+                onClick={e => button.callback(e, row)}>
                 {button.name}
             </div>
         )


### PR DESCRIPTION
⚠️ Breaking change.

* The event object is now the first parameter rather than the row.
* `checkboxChange` is no longer an object, instead it follows all other DataRow event callbacks.