### PR TITLE
Check for window before accessing

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -239,6 +239,12 @@ function (_Component) {
   return AjaxDynamicDataTable;
 }(_react.Component);
 
+var axios;
+
+if (typeof window !== 'undefined') {
+  axios = window.axios;
+}
+
 AjaxDynamicDataTable.defaultProps = {
   onLoad: function onLoad() {
     return null;
@@ -246,7 +252,7 @@ AjaxDynamicDataTable.defaultProps = {
   params: {},
   defaultOrderByField: null,
   defaultOrderByDirection: null,
-  axios: window.axios || require('axios'),
+  axios: axios || require('axios'),
   disallowOrderingBy: []
 };
 AjaxDynamicDataTable.propTypes = {

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -246,7 +246,7 @@ AjaxDynamicDataTable.defaultProps = {
   params: {},
   defaultOrderByField: null,
   defaultOrderByDirection: null,
-  axios: window && window.axios ? window.axios : require('axios'),
+  axios: typeof window !== 'undefined' && window.axios ? window.axios : require('axios'),
   disallowOrderingBy: []
 };
 AjaxDynamicDataTable.propTypes = {

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -239,12 +239,6 @@ function (_Component) {
   return AjaxDynamicDataTable;
 }(_react.Component);
 
-var axios;
-
-if (typeof window !== 'undefined') {
-  axios = window.axios;
-}
-
 AjaxDynamicDataTable.defaultProps = {
   onLoad: function onLoad() {
     return null;
@@ -252,7 +246,7 @@ AjaxDynamicDataTable.defaultProps = {
   params: {},
   defaultOrderByField: null,
   defaultOrderByDirection: null,
-  axios: axios || require('axios'),
+  axios: window && window.axios ? window.axios : require('axios'),
   disallowOrderingBy: []
 };
 AjaxDynamicDataTable.propTypes = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -118,7 +118,8 @@ AjaxDynamicDataTable.defaultProps = {
     params: {},
     defaultOrderByField: null,
     defaultOrderByDirection: null,
-    axios: (window && window.axios) ? window.axios : require('axios'),
+    axios: typeof window !== 'undefined' && window.axios 
+        ? window.axios : require('axios'),
     disallowOrderingBy: [],
 };
 

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -113,18 +113,12 @@ class AjaxDynamicDataTable extends Component {
 
 }
 
-let axios;
-
-if (typeof window !== 'undefined') {
-    axios = window.axios
-}
-
 AjaxDynamicDataTable.defaultProps = {
     onLoad: () => null,
     params: {},
     defaultOrderByField: null,
     defaultOrderByDirection: null,
-    axios: axios || require('axios'),
+    axios: (window && window.axios) ? window.axios : require('axios'),
     disallowOrderingBy: [],
 };
 

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -113,12 +113,18 @@ class AjaxDynamicDataTable extends Component {
 
 }
 
+let axios;
+
+if (typeof window !== 'undefined') {
+    axios = window.axios
+}
+
 AjaxDynamicDataTable.defaultProps = {
     onLoad: () => null,
     params: {},
     defaultOrderByField: null,
     defaultOrderByDirection: null,
-    axios: window.axios || require('axios'),
+    axios: axios || require('axios'),
     disallowOrderingBy: [],
 };
 


### PR DESCRIPTION
As `defaultProps` is static and read instantly this causes issues with SSR because `window` does not exist when components are ran on the server.

[Next](https://github.com/zeit/next.js) has [a solution](https://github.com/zeit/next.js#with-no-ssr) for this. But I am not sure what other frameworks and the like do.
