### PR TITLE
Remove empty cells when no buttons or actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ The argument passed to the `rowRenderer` callable is a JavaScript object that co
   row,                // Instance of data row
   onClick,            // Row on click handler
   buttons,            // Array of buttons
+  actions,            // Array of header actions
   fields,             // Visible fields
   renderCheckboxes,   // Boolean indicating whether to render checkboxes
   checkboxIsChecked,  // Boolean indicating if checkbox is checked

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Actions, when combined with bulk select checkboxes allow you perform
 actions of multiple rows at once. When in use, a menu will be rendered
 in the top right of the table allowing your users to choose a bulk action
 that will be applied to the selected rows.
-
+Actions can also be used without bulk select checkboxes. This could allow for creation of action buttons that are not dependant on existing data, such as a 'Create User' button.
 To use actions in your React Dynamic Data Table, you must specify the
 `actions` props. This prop expects an array of objects, each containing a `name` 
 and `callback`.

--- a/README.md
+++ b/README.md
@@ -457,7 +457,9 @@ Actions, when combined with bulk select checkboxes allow you perform
 actions of multiple rows at once. When in use, a menu will be rendered
 in the top right of the table allowing your users to choose a bulk action
 that will be applied to the selected rows.
+
 Actions can also be used without bulk select checkboxes. This could allow for creation of action buttons that are not dependant on existing data, such as a 'Create User' button.
+
 To use actions in your React Dynamic Data Table, you must specify the
 `actions` props. This prop expects an array of objects, each containing a `name` 
 and `callback`.

--- a/README.md
+++ b/README.md
@@ -450,14 +450,14 @@ checkboxes against each row, on the left side of the table.
 Bulk select checkboxes are usually combined with bulk actions to perform
 actions on one or more rows at once.
 
-### Bulk actions
+### Actions
 
-Bulk actions, when combined with bulk select checkboxes allow you perform
+Actions, when combined with bulk select checkboxes allow you perform
 actions of multiple rows at once. When in use, a menu will be rendered
 in the top right of the table allowing your users to choose a bulk action
 that will be applied to the selected rows.
 
-To use bulk actions in your React Dynamic Data Table, you must specify the
+To use actions in your React Dynamic Data Table, you must specify the
 `actions` props. This prop expects an array of objects, each containing a `name` 
 and `callback`.
 
@@ -466,7 +466,7 @@ The `name` is string, such as 'Delete user(s)', 'Duplicate user(s)' etc.
 The `callback` is a callable with a single argument. The argument will
 contain an array of the selected rows. 
 
-An example of show to use bulk actions is shown below.
+Examples of how to use actions is shown below.
 
 ```JSX
 <DynamicDataTable
@@ -477,6 +477,20 @@ An example of show to use bulk actions is shown below.
             name: 'Delete user(s)',
             callback: (rows) => { 
                 // Delete users...
+            },
+        },
+    ]}
+/>
+```
+
+```JSX
+<DynamicDataTable
+    rows={this.state.users}
+    actions={[
+        {
+            name: 'Create user',
+            callback: () => { 
+                // Toggle create user modal...
             },
         },
     ]}

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -150,7 +150,9 @@ function (_Component) {
     value: function renderButtons(row) {
       var _this3 = this;
 
-      var buttons = this.props.buttons;
+      var _this$props3 = this.props,
+          buttons = _this$props3.buttons,
+          actions = _this$props3.actions;
 
       if (typeof buttons === 'function') {
         return buttons(row);
@@ -158,7 +160,7 @@ function (_Component) {
 
       if (!buttons.length && !actions.length) {
         return null;
-      } else if (!buttons.legth) {
+      } else if (!buttons.length) {
         return _react["default"].createElement("td", null);
       }
 

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -156,7 +156,9 @@ function (_Component) {
         return buttons(row);
       }
 
-      if (!buttons.length) {
+      if (!buttons.length && !actions.length) {
+        return null;
+      } else if (!buttons.legth) {
         return _react["default"].createElement("td", null);
       }
 
@@ -246,11 +248,13 @@ function (_Component) {
 DataRow.defaultProps = {
   onClick: DataRow.noop,
   onContextMenu: DataRow.noop,
-  dangerouslyRenderFields: []
+  dangerouslyRenderFields: [],
+  actions: []
 };
 DataRow.propTypes = {
   row: _propTypes["default"].object,
   buttons: _propTypes["default"].oneOfType([_propTypes["default"].array, _propTypes["default"].func]),
+  actions: _propTypes["default"].array,
   checkboxIsChecked: _propTypes["default"].func,
   checkboxChange: _propTypes["default"].func,
   dataItemManipulator: _propTypes["default"].func,

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -348,10 +348,14 @@ function (_Component) {
     value: function renderActionsCell() {
       var _this5 = this;
 
-      var props = this.props;
+      var _this$props6 = this.props,
+          actions = _this$props6.actions,
+          buttons = _this$props6.buttons;
       var state = this.state;
 
-      if (!props.renderCheckboxes || !this.props.actions.length) {
+      if (!buttons.length && !actions.length) {
+        return null;
+      } else if (!actions.length) {
         return _react["default"].createElement("th", null);
       }
 
@@ -517,10 +521,10 @@ function (_Component) {
   }, {
     key: "renderLoadingTable",
     value: function renderLoadingTable() {
-      var _this$props6 = this.props,
-          loadingIndicator = _this$props6.loadingIndicator,
-          loadingMessage = _this$props6.loadingMessage,
-          loadingComponent = _this$props6.loadingComponent;
+      var _this$props7 = this.props,
+          loadingIndicator = _this$props7.loadingIndicator,
+          loadingMessage = _this$props7.loadingMessage,
+          loadingComponent = _this$props7.loadingComponent;
 
       if (loadingComponent) {
         return loadingComponent;
@@ -548,9 +552,9 @@ function (_Component) {
   }, {
     key: "renderEmptyTable",
     value: function renderEmptyTable() {
-      var _this$props7 = this.props,
-          noDataMessage = _this$props7.noDataMessage,
-          noDataComponent = _this$props7.noDataComponent;
+      var _this$props8 = this.props,
+          noDataMessage = _this$props8.noDataMessage,
+          noDataComponent = _this$props8.noDataComponent;
 
       if (_react["default"].isValidElement(noDataComponent)) {
         return noDataComponent;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -291,7 +291,8 @@ function (_Component) {
           renderCheckboxes = _this$props4.renderCheckboxes,
           _dataItemManipulator = _this$props4.dataItemManipulator,
           rowRenderer = _this$props4.rowRenderer,
-          dangerouslyRenderFields = _this$props4.dangerouslyRenderFields;
+          dangerouslyRenderFields = _this$props4.dangerouslyRenderFields,
+          actions = _this$props4.actions;
       return rowRenderer({
         row: row,
         onClick: onClick,
@@ -308,7 +309,8 @@ function (_Component) {
         onCheckboxChange: function onCheckboxChange(e) {
           return _this3.checkboxChange(e);
         },
-        dangerouslyRenderFields: dangerouslyRenderFields
+        dangerouslyRenderFields: dangerouslyRenderFields,
+        actions: actions
       });
     }
   }, {
@@ -591,13 +593,15 @@ function (_Component) {
           checkboxIsChecked = _ref2.checkboxIsChecked,
           onCheckboxChange = _ref2.onCheckboxChange,
           _dataItemManipulator2 = _ref2.dataItemManipulator,
-          dangerouslyRenderFields = _ref2.dangerouslyRenderFields;
+          dangerouslyRenderFields = _ref2.dangerouslyRenderFields,
+          actions = _ref2.actions;
       return _react["default"].createElement(_DataRow["default"], {
         key: row.id,
         row: row,
         onClick: onClick,
         buttons: buttons,
         fields: fields,
+        actions: actions,
         renderCheckboxes: renderCheckboxes,
         checkboxIsChecked: checkboxIsChecked,
         checkboxChange: onCheckboxChange,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.0.2",
+  "version": "7.1.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -86,8 +86,10 @@ class DataRow extends Component {
             return buttons(row);
         }
 
-        if (!buttons.length) {
-            return ( <td></td> );
+        if (!buttons.length && !actions.length) {
+            return null;
+        } else if (!buttons.legth) {
+            return <td />;
         }
 
         const button = buttons[0];
@@ -167,6 +169,7 @@ DataRow.defaultProps = {
     onClick: DataRow.noop,
     onContextMenu: DataRow.noop,
     dangerouslyRenderFields: [],
+    actions: [],
 };
 
 DataRow.propTypes = {
@@ -174,6 +177,7 @@ DataRow.propTypes = {
     buttons: PropTypes.oneOfType([
         PropTypes.array, PropTypes.func,
     ]),
+    actions: PropTypes.array,
     checkboxIsChecked: PropTypes.func,
     checkboxChange: PropTypes.func,
     dataItemManipulator: PropTypes.func,

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -80,7 +80,7 @@ class DataRow extends Component {
     }
 
     renderButtons(row) {
-        const { buttons } = this.props;
+        const { buttons, actions } = this.props;
 
         if (typeof buttons === 'function') {
             return buttons(row);
@@ -88,7 +88,7 @@ class DataRow extends Component {
 
         if (!buttons.length && !actions.length) {
             return null;
-        } else if (!buttons.legth) {
+        } else if (!buttons.length) {
             return <td />;
         }
 

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -20,7 +20,7 @@ class DynamicDataTable extends Component {
         return null;
     }
 
-    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator, dangerouslyRenderFields }) {
+    static rowRenderer({ row, onClick, buttons, fields, renderCheckboxes, checkboxIsChecked, onCheckboxChange, dataItemManipulator, dangerouslyRenderFields, actions }) {
         return (
             <DataRow
                 key={row.id}
@@ -28,6 +28,7 @@ class DynamicDataTable extends Component {
                 onClick={onClick}
                 buttons={buttons}
                 fields={fields}
+                actions={actions}
                 renderCheckboxes={renderCheckboxes}
                 checkboxIsChecked={checkboxIsChecked}
                 checkboxChange={onCheckboxChange}
@@ -222,7 +223,7 @@ class DynamicDataTable extends Component {
 
     renderRow(row) {
         const {
-            onClick, buttons, renderCheckboxes, dataItemManipulator, rowRenderer, dangerouslyRenderFields
+            onClick, buttons, renderCheckboxes, dataItemManipulator, rowRenderer, dangerouslyRenderFields, actions
         } = this.props;
 
         return rowRenderer({
@@ -236,6 +237,7 @@ class DynamicDataTable extends Component {
             checkboxIsChecked: (value) => this.checkboxIsChecked(value),
             onCheckboxChange: (e) => this.checkboxChange(e),
             dangerouslyRenderFields,
+            actions
         });
     }
 

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -276,13 +276,13 @@ class DynamicDataTable extends Component {
     }
 
     renderActionsCell() {
-        const props = this.props;
+        const { actions, buttons } = this.props;
         const state = this.state;
 
-        if (!props.renderCheckboxes || !this.props.actions.length) {
-            return (
-                <th/>
-            );
+        if (!buttons.length && !actions.length) {
+            return null;
+        } else if (!actions.length) {
+            return <th />;
         }
 
         return (


### PR DESCRIPTION
This has always confused me a little. I'm not 100% sure why an empty cell would be kept around when no actions or buttons were present; this PR removes the empty cells when no buttons or actions are passed.

One other change is that previously it would check for `renderCheckboxes` before rendering actions within the header. I think that actions should be actionable even without `renderCheckboxes`. For example a create button might go here in some situations.

I don't believe this is a breaking change, so perhaps could be versioned as `7.1.0`?


Closes #40 