### PR TITLE
Add disabledCheckboxes prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ The argument passed to the `rowRenderer` callable is a JavaScript object that co
   actions,            // Array of header actions
   fields,             // Visible fields
   renderCheckboxes,   // Boolean indicating whether to render checkboxes
+  disableCheckbox,    // Boolean indicating whether to disable the checkbox per row
   checkboxIsChecked,  // Boolean indicating if checkbox is checked
   onCheckboxChange,   // Callable that is called when a per row checkbox is changed
   dataItemManipulator // Callable that handles manipulation of every item in the data row
@@ -505,6 +506,19 @@ checkboxes against each row, on the left side of the table.
 
 Bulk select checkboxes are usually combined with bulk actions to perform
 actions on one or more rows at once.
+
+### Disable checkboxes
+
+Checkboxes can also be disabled for each individual row by passing in `disabledCheckboxes` which
+should container an array of identifiers. If an identifier is in the array then the checkbox will have `disabled` set to `true`.
+
+```JSX
+<DynamicDataTable
+    rows={this.state.users}
+    renderCheckboxes
+    disabledCheckboxes={[1]}
+    />
+```
 
 ### Actions
 

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -116,7 +116,8 @@ function (_Component) {
 
       var _this$props2 = this.props,
           row = _this$props2.row,
-          renderCheckboxes = _this$props2.renderCheckboxes;
+          renderCheckboxes = _this$props2.renderCheckboxes,
+          disableCheckbox = _this$props2.disableCheckbox;
 
       if (!renderCheckboxes) {
         return;
@@ -133,7 +134,8 @@ function (_Component) {
         },
         onClick: function onClick(e) {
           return e.stopPropagation();
-        }
+        },
+        disabled: disableCheckbox
       }));
 
       return _react["default"].createElement("td", null, checkbox);

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -303,6 +303,7 @@ function (_Component) {
           onMouseDown = _this$props4.onMouseDown,
           buttons = _this$props4.buttons,
           renderCheckboxes = _this$props4.renderCheckboxes,
+          disabledCheckboxes = _this$props4.disabledCheckboxes,
           _dataItemManipulator = _this$props4.dataItemManipulator,
           rowRenderer = _this$props4.rowRenderer,
           dangerouslyRenderFields = _this$props4.dangerouslyRenderFields,
@@ -315,6 +316,7 @@ function (_Component) {
         onMouseDown: onMouseDown,
         buttons: buttons,
         renderCheckboxes: renderCheckboxes,
+        disableCheckbox: disabledCheckboxes.includes(row.id),
         key: row.id,
         fields: this.getFields(),
         dataItemManipulator: function dataItemManipulator(field, value, row) {
@@ -475,10 +477,15 @@ function (_Component) {
     key: "checkboxIsChecked",
     value: function checkboxIsChecked(row) {
       var checkedRows = this.state.checkedRows;
-      var rows = this.props.rows;
+      var _this$props7 = this.props,
+          rows = _this$props7.rows,
+          disabledCheckboxes = _this$props7.disabledCheckboxes;
 
       if (row === 'all') {
-        return checkedRows.length === rows.length;
+        return checkedRows.length === rows.filter(function (_ref) {
+          var id = _ref.id;
+          return !disabledCheckboxes.includes(id);
+        }).length;
       }
 
       var index = -1;
@@ -498,13 +505,18 @@ function (_Component) {
   }, {
     key: "checkboxChange",
     value: function checkboxChange(event, row) {
-      var rows = this.props.rows;
+      var _this$props8 = this.props,
+          rows = _this$props8.rows,
+          disabledCheckboxes = _this$props8.disabledCheckboxes;
       var target = event.target;
 
       if (row === 'all') {
         if (target.checked) {
           var _checkedRows = [];
-          rows.forEach(function (row) {
+          rows.filter(function (_ref2) {
+            var id = _ref2.id;
+            return !disabledCheckboxes.includes(id);
+          }).forEach(function (row) {
             return _checkedRows.push(row);
           });
           this.setState({
@@ -549,10 +561,10 @@ function (_Component) {
   }, {
     key: "renderLoadingTable",
     value: function renderLoadingTable() {
-      var _this$props7 = this.props,
-          loadingIndicator = _this$props7.loadingIndicator,
-          loadingMessage = _this$props7.loadingMessage,
-          loadingComponent = _this$props7.loadingComponent;
+      var _this$props9 = this.props,
+          loadingIndicator = _this$props9.loadingIndicator,
+          loadingMessage = _this$props9.loadingMessage,
+          loadingComponent = _this$props9.loadingComponent;
 
       if (loadingComponent) {
         return loadingComponent;
@@ -580,9 +592,9 @@ function (_Component) {
   }, {
     key: "renderEmptyTable",
     value: function renderEmptyTable() {
-      var _this$props8 = this.props,
-          noDataMessage = _this$props8.noDataMessage,
-          noDataComponent = _this$props8.noDataComponent;
+      var _this$props10 = this.props,
+          noDataMessage = _this$props10.noDataMessage,
+          noDataComponent = _this$props10.noDataComponent;
 
       if (_react["default"].isValidElement(noDataComponent)) {
         return noDataComponent;
@@ -616,21 +628,22 @@ function (_Component) {
     }
   }, {
     key: "rowRenderer",
-    value: function rowRenderer(_ref) {
-      var row = _ref.row,
-          onClick = _ref.onClick,
-          buttons = _ref.buttons,
-          fields = _ref.fields,
-          onMouseUp = _ref.onMouseUp,
-          onMouseDown = _ref.onMouseDown,
-          renderCheckboxes = _ref.renderCheckboxes,
-          checkboxIsChecked = _ref.checkboxIsChecked,
-          onCheckboxChange = _ref.onCheckboxChange,
-          _dataItemManipulator2 = _ref.dataItemManipulator,
-          dangerouslyRenderFields = _ref.dangerouslyRenderFields,
-          actions = _ref.actions,
-          editableColumns = _ref.editableColumns,
-          index = _ref.index;
+    value: function rowRenderer(_ref3) {
+      var row = _ref3.row,
+          onClick = _ref3.onClick,
+          buttons = _ref3.buttons,
+          fields = _ref3.fields,
+          onMouseUp = _ref3.onMouseUp,
+          onMouseDown = _ref3.onMouseDown,
+          renderCheckboxes = _ref3.renderCheckboxes,
+          disableCheckbox = _ref3.disableCheckbox,
+          checkboxIsChecked = _ref3.checkboxIsChecked,
+          onCheckboxChange = _ref3.onCheckboxChange,
+          _dataItemManipulator2 = _ref3.dataItemManipulator,
+          dangerouslyRenderFields = _ref3.dangerouslyRenderFields,
+          actions = _ref3.actions,
+          editableColumns = _ref3.editableColumns,
+          index = _ref3.index;
       return _react["default"].createElement(_DataRow["default"], {
         key: row.id,
         row: row,
@@ -641,6 +654,7 @@ function (_Component) {
         fields: fields,
         actions: actions,
         renderCheckboxes: renderCheckboxes,
+        disableCheckbox: disableCheckbox,
         editableColumns: editableColumns,
         checkboxIsChecked: checkboxIsChecked,
         checkboxChange: onCheckboxChange,
@@ -668,6 +682,7 @@ DynamicDataTable.propTypes = {
   orderByAscIcon: _propTypes["default"].node,
   orderByDescIcon: _propTypes["default"].node,
   renderCheckboxes: _propTypes["default"].bool,
+  disabledCheckboxes: _propTypes["default"].arrayOf(_propTypes["default"].oneOfType([_propTypes["default"].number, _propTypes["default"].string])),
   editableColumns: _propTypes["default"].arrayOf(_propTypes["default"].shape({
     name: _propTypes["default"].string.isRequired,
     controlled: _propTypes["default"].bool.isRequired,
@@ -708,6 +723,7 @@ DynamicDataTable.defaultProps = {
   orderByAscIcon: '↓',
   orderByDescIcon: '↑',
   renderCheckboxes: false,
+  disabledCheckboxes: [],
   editableColumns: [],
   actions: [],
   loading: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.7.1",
+  "version": "7.8.1",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -31,7 +31,7 @@ class DataRow extends Component {
     }
 
     renderCheckboxCell() {
-        const { row, renderCheckboxes } = this.props;
+        const { row, renderCheckboxes, disableCheckbox } = this.props;
 
         if (!renderCheckboxes) {
             return;
@@ -45,6 +45,7 @@ class DataRow extends Component {
                     checked={this.props.checkboxIsChecked(row)}
                     onChange={e => this.props.checkboxChange(e, row)}
                     onClick={e => e.stopPropagation()}
+                    disabled={disableCheckbox}
                 />
             </div>
         );


### PR DESCRIPTION
This PR implements the functionality to pass an array of identifiers into the `disabledCheckboxes` prop which then allows for individual checkbox disabling per row.

Example:
```jsx
<DynamicDataTable
    rows={this.state.users}
    renderCheckboxes
    disabledCheckboxes={[1]}
/>
```