### PR TITLE
External loading

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -147,8 +147,7 @@ function (_Component) {
           currentPage = _this$state.currentPage,
           totalPages = _this$state.totalPages,
           orderByField = _this$state.orderByField,
-          orderByDirection = _this$state.orderByDirection,
-          loading = _this$state.loading;
+          orderByDirection = _this$state.orderByDirection;
 
       var _this$props = this.props,
           disallowOrderingBy = _this$props.disallowOrderingBy,
@@ -160,7 +159,7 @@ function (_Component) {
         totalPages: totalPages,
         orderByField: orderByField,
         orderByDirection: orderByDirection,
-        loading: loading,
+        loading: this.loading,
         changePage: this.changePage,
         changeOrder: this.changeOrder,
         disallowOrderingBy: this.disallowOrderingBy
@@ -237,6 +236,13 @@ function (_Component) {
       });
     }
   }, {
+    key: "loading",
+    get: function get() {
+      var state = this.state.loading;
+      var prop = this.props.loading;
+      return state || prop;
+    }
+  }, {
     key: "disallowOrderingBy",
     get: function get() {
       var state = this.state.disallowOrderingBy;
@@ -252,6 +258,7 @@ AjaxDynamicDataTable.defaultProps = {
   onLoad: function onLoad() {
     return null;
   },
+  loading: false,
   params: {},
   defaultOrderByField: null,
   defaultOrderByDirection: null,
@@ -261,6 +268,7 @@ AjaxDynamicDataTable.defaultProps = {
 AjaxDynamicDataTable.propTypes = {
   apiUrl: _propTypes["default"].string,
   onLoad: _propTypes["default"].func,
+  loading: _propTypes["default"].bool,
   params: _propTypes["default"].object,
   defaultOrderByField: _propTypes["default"].string,
   defaultOrderByDirection: _propTypes["default"].string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -33,6 +33,13 @@ class AjaxDynamicDataTable extends Component {
         }
     }
 
+    get loading() {
+        const { loading: state } = this.state;
+        const { loading: prop } = this.props;
+
+        return state || prop;
+    }
+
     get disallowOrderingBy() {
         const { disallowOrderingBy: state } = this.state;
         const { disallowOrderingBy: prop } = this.props;
@@ -40,12 +47,12 @@ class AjaxDynamicDataTable extends Component {
         return [
             ...state,
             ...prop
-        ]
+        ];
     }
 
     render() {
 
-        const { rows, currentPage, totalPages, orderByField, orderByDirection, loading } = this.state;
+        const { rows, currentPage, totalPages, orderByField, orderByDirection } = this.state;
         const { disallowOrderingBy, ...props } = this.props;
 
         return (
@@ -55,7 +62,7 @@ class AjaxDynamicDataTable extends Component {
                 totalPages={totalPages}
                 orderByField={orderByField}
                 orderByDirection={orderByDirection}
-                loading={loading}
+                loading={this.loading}
                 changePage={this.changePage}
                 changeOrder={this.changeOrder}
                 disallowOrderingBy={this.disallowOrderingBy}
@@ -119,6 +126,7 @@ class AjaxDynamicDataTable extends Component {
 
 AjaxDynamicDataTable.defaultProps = {
     onLoad: () => null,
+    loading: false,
     params: {},
     defaultOrderByField: null,
     defaultOrderByDirection: null,
@@ -130,6 +138,7 @@ AjaxDynamicDataTable.defaultProps = {
 AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
     onLoad: PropTypes.func,
+    loading: PropTypes.bool,
     params: PropTypes.object,
     defaultOrderByField: PropTypes.string,
     defaultOrderByDirection: PropTypes.string,


### PR DESCRIPTION
This PR implemented the `loading` prop which can be used to control the loading state of the table when internal loading is `false`.

This is useful when needing to load extra data after the table has loaded.

Example:
```jsx
class Page extends React.Component {
  // ...

  onFilterChange(filters) {
    this.setState({
      filters,

      // Disable filter component
      loading: true,
    })
  }

  onLoad({ rows }) {

    // Get additional information after table has loaded
    new Promise(resolve => (
      this.setState({
        rows,
        // Enable filter component
        loading: false,
      })
   ))
  }

  render() {
    const { rows, loading } = this.state

    return (
      <React.Fragment>
        <Filter
          disabled={loading}
          onChange={this.onFilterChange}
        />
        <AjaxDynamicDataTable
          rows={rows}
          loading={loading}
          onLoad={this.onLoad}
        />
      </React.Fragment>
    )
  }
}
```