### PR TITLE
Implement per page renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,42 @@ This delta can be changed by passing a `paginationDelta` prop into `DynamicDataT
     />
 ```
 
+### Per page limiting
+
+Changing the number of entries displaying in the data table is easy. The `totalRows`, `perPage`, `changePerPage` and `perPageRenderer` allow you to customize a per page limit control.
+
+* `totalRows` the total number of rows within the dataset
+* `perPage` the current per page limit (default: `15`)
+* `changePerPage` handles the logic for changing the `perPage` prop. This recieved a single argument which is the new limit.
+* `perPageRender` can either be a node or a function.
+
+By default a Bootstrap styled select is displayed if `changePerPage` is a function.
+
+```jsx
+<DynamicDataTable
+    totalRows={totalRows}
+    perPage={perPage}
+    changePerPage={newPerPage => (
+        this.setState({
+            perPage: newPerPage
+        })
+    )}
+    perPageRenderer={props => (
+        <PerPage {...props} />
+    )}
+/>
+```
+
+#### `perPageRenderer`
+
+The `perPageRenderer` prop accepts either a node or function. If a valid react element is passed then `React.cloneElement` is used to bind:
+
+* `totalRows`
+* `value` (see `perPage` above)
+* `onChange` (see `changePerPage` above)
+
+If a function is passed then the props described above are passed in an object.
+
 ### Row buttons
 
 Row buttons appear on the right hand side of every row in the React Dynamic Data 

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -59,7 +59,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -115,7 +115,9 @@ function (_Component) {
     _this.state = {
       rows: [],
       currentPage: 1,
+      perPage: 15,
       totalPages: 1,
+      totalRows: 0,
       orderByField: defaultOrderByField,
       orderByDirection: defaultOrderByDirection,
       disallowOrderingBy: [],
@@ -124,6 +126,7 @@ function (_Component) {
     _this.reload = _this.reload.bind(_assertThisInitialized(_this));
     _this.changePage = _this.changePage.bind(_assertThisInitialized(_this));
     _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_this));
+    _this.changePerPage = _this.changePerPage.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -144,7 +147,9 @@ function (_Component) {
     value: function render() {
       var _this$state = this.state,
           rows = _this$state.rows,
+          totalRows = _this$state.totalRows,
           currentPage = _this$state.currentPage,
+          perPage = _this$state.perPage,
           totalPages = _this$state.totalPages,
           orderByField = _this$state.orderByField,
           orderByDirection = _this$state.orderByDirection;
@@ -155,13 +160,16 @@ function (_Component) {
 
       return _react["default"].createElement(_DynamicDataTable["default"], _extends({
         rows: rows,
+        totalRows: totalRows,
         currentPage: currentPage,
+        perPage: perPage,
         totalPages: totalPages,
         orderByField: orderByField,
         orderByDirection: orderByDirection,
         loading: this.loading,
         changePage: this.changePage,
         changeOrder: this.changeOrder,
+        changePerPage: this.changePerPage,
         disallowOrderingBy: this.disallowOrderingBy
       }, props));
     }
@@ -177,6 +185,7 @@ function (_Component) {
       var _this2 = this;
 
       var _this$state2 = this.state,
+          perPage = _this$state2.perPage,
           orderByField = _this$state2.orderByField,
           orderByDirection = _this$state2.orderByDirection;
       var _this$props2 = this.props,
@@ -189,6 +198,7 @@ function (_Component) {
         axios.get(_this2.props.apiUrl, {
           params: _objectSpread({}, params, {
             page: page,
+            perPage: perPage,
             orderByField: orderByField,
             orderByDirection: orderByDirection
           })
@@ -196,6 +206,7 @@ function (_Component) {
           var response = _ref.data;
           var _response$data = response.data,
               rows = _response$data.data,
+              total = _response$data.total,
               current_page = _response$data.current_page,
               last_page = _response$data.last_page;
           var disallow_ordering_by = [];
@@ -207,6 +218,7 @@ function (_Component) {
           var newState = {
             disallowOrderingBy: disallow_ordering_by,
             rows: rows,
+            totalRows: total,
             currentPage: current_page,
             totalPages: last_page,
             loading: false
@@ -222,6 +234,13 @@ function (_Component) {
     key: "changePage",
     value: function changePage(page) {
       this.loadPage(page);
+    }
+  }, {
+    key: "changePerPage",
+    value: function changePerPage(limit) {
+      this.setState({
+        perPage: limit
+      }, this.reload);
     }
   }, {
     key: "changeOrder",

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -43,7 +43,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -334,7 +334,7 @@ DataRow.propTypes = {
   onMouseDown: _propTypes["default"].func,
   onContextMenu: _propTypes["default"].func,
   dangerouslyRenderFields: _propTypes["default"].array,
-  index: _propTypes["default"].number.required
+  index: _propTypes["default"].number.isRequired
 };
 var _default = DataRow;
 exports["default"] = _default;

--- a/dist/Components/PerPage.js
+++ b/dist/Components/PerPage.js
@@ -25,7 +25,9 @@ require("core-js/modules/es6.object.create");
 
 require("core-js/modules/es6.object.set-prototype-of");
 
-require("core-js/modules/es6.array.for-each");
+require("core-js/modules/es6.array.map");
+
+require("core-js/modules/es6.function.bind");
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -47,130 +49,88 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
-var Pagination =
+var PerPage =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Pagination, _Component);
+  _inherits(PerPage, _Component);
 
-  function Pagination() {
-    _classCallCheck(this, Pagination);
+  function PerPage(props) {
+    var _this;
 
-    return _possibleConstructorReturn(this, _getPrototypeOf(Pagination).apply(this, arguments));
+    _classCallCheck(this, PerPage);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(PerPage).call(this, props));
+    _this.onChange = _this.onChange.bind(_assertThisInitialized(_this));
+    return _this;
   }
 
-  _createClass(Pagination, [{
+  _createClass(PerPage, [{
+    key: "onChange",
+    value: function onChange(_ref) {
+      var value = _ref.target.value;
+      var onChange = this.props.onChange;
+      onChange(value);
+    }
+  }, {
     key: "render",
     value: function render() {
-      var _this = this;
-
-      var pageLinks = [];
-      var props = this.props;
-      var currentPage = props.currentPage;
-      var totalPages = props.totalPages;
-
-      if (totalPages <= 1) {
-        return null;
-      }
-
-      this.getPagesToDisplay(currentPage, totalPages).forEach(function (page, index) {
-        pageLinks.push(_react["default"].createElement("li", {
-          key: "page_index_".concat(index),
-          className: "page-item ".concat(currentPage === page ? 'active' : '')
-        }, _react["default"].createElement("button", {
-          type: "button",
-          className: "page-link ".concat(!page ? 'disabled' : ''),
-          onClick: function onClick() {
-            if (page) {
-              _this.changePage(page);
-            }
-          }
-        }, page || '...')));
-      });
-      return _react["default"].createElement("nav", {
-        "aria-label": "Page navigation ml-auto"
-      }, _react["default"].createElement("ul", {
-        className: "pagination mb-0"
-      }, _react["default"].createElement("li", {
-        className: "page-item ".concat(currentPage <= 1 ? 'disabled' : '')
-      }, _react["default"].createElement("button", {
-        type: "button",
-        className: "page-link",
-        onClick: function onClick() {
-          return _this.previousPage();
-        }
-      }, "Previous")), pageLinks, _react["default"].createElement("li", {
-        className: "page-item ".concat(currentPage >= totalPages ? 'disabled' : '')
-      }, _react["default"].createElement("button", {
-        type: "button",
-        className: "page-link",
-        onClick: function onClick() {
-          return _this.nextPage();
-        }
-      }, "Next"))));
-    }
-  }, {
-    key: "changePage",
-    value: function changePage(page) {
-      this.props.changePage(page);
-    }
-  }, {
-    key: "previousPage",
-    value: function previousPage() {
-      if (this.props.currentPage > 1) {
-        this.changePage(this.props.currentPage - 1);
-      }
-    }
-  }, {
-    key: "nextPage",
-    value: function nextPage() {
-      if (this.props.currentPage < this.props.totalPages) {
-        this.changePage(this.props.currentPage + 1);
-      }
-    }
-  }, {
-    key: "getPagesToDisplay",
-    value: function getPagesToDisplay(currentPage, totalPages) {
-      var paginationDelta = this.props.paginationDelta;
-      var pages = [];
-
-      for (var i = 1; i <= totalPages; i++) {
-        var isFirstPage = i === 1;
-        var isLastPage = i === totalPages;
-        var isWithinDelta = Math.abs(currentPage - i) <= paginationDelta;
-
-        if (isFirstPage || isLastPage || isWithinDelta) {
-          // If this element isn't directly sequential to the last, add a filler null element.
-          if (pages.length >= 1 && i !== pages[pages.length - 1] + 1) {
-            pages.push(null);
-          }
-
-          pages.push(i);
-        }
-      }
-
-      return pages;
+      var _this$props = this.props,
+          _this$props$className = _this$props.className,
+          container = _this$props$className.container,
+          innerContainer = _this$props$className.innerContainer,
+          select = _this$props$className.select,
+          value = _this$props.value,
+          defaultValue = _this$props.defaultValue,
+          options = _this$props.options,
+          totalRows = _this$props.totalRows;
+      return _react["default"].createElement("div", {
+        className: container
+      }, _react["default"].createElement("span", null, "Showing"), _react["default"].createElement("div", {
+        className: innerContainer
+      }, _react["default"].createElement("select", {
+        className: select,
+        value: value || defaultValue,
+        onChange: this.onChange
+      }, options.map(function (option) {
+        return _react["default"].createElement("option", {
+          key: option,
+          value: option
+        }, option);
+      }))), _react["default"].createElement("span", null, "of ", totalRows, " records"));
     }
   }]);
 
-  return Pagination;
+  return PerPage;
 }(_react.Component);
 
-Pagination.defaultProps = {
-  paginationDelta: 4
+PerPage.defaultProps = {
+  className: {
+    container: 'd-flex align-items-center',
+    innerContainer: 'form-group mb-0 mx-sm-3 mx-2',
+    select: 'form-control'
+  },
+  defaultValue: 15,
+  options: [10, 15, 30, 50, 75, 100]
 };
-Pagination.propTypes = {
-  currentPage: _propTypes["default"].number,
-  totalPages: _propTypes["default"].number,
-  changePage: _propTypes["default"].func,
-  paginationDelta: _propTypes["default"].number
+PerPage.propTypes = {
+  onChange: _propTypes["default"].func.isRequired,
+  totalRows: _propTypes["default"].number.isRequired,
+  value: _propTypes["default"].oneOfType([_propTypes["default"].number, _propTypes["default"].string]).isRequired,
+  defaultValue: _propTypes["default"].oneOfType([_propTypes["default"].number, _propTypes["default"].string]),
+  className: _propTypes["default"].shape({
+    container: _propTypes["default"].string,
+    innerContainer: _propTypes["default"].string,
+    select: _propTypes["default"].string
+  }),
+  options: _propTypes["default"].arrayOf(_propTypes["default"].number)
 };
-var _default = Pagination;
+var _default = PerPage;
 exports["default"] = _default;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -21,13 +21,13 @@ require("core-js/modules/es6.object.create");
 
 require("core-js/modules/es6.object.set-prototype-of");
 
+require("core-js/modules/es6.array.map");
+
 require("core-js/modules/es6.array.for-each");
 
 require("core-js/modules/es7.array.includes");
 
 require("core-js/modules/es6.string.includes");
-
-require("core-js/modules/es6.array.map");
 
 require("core-js/modules/es6.array.is-array");
 
@@ -65,13 +65,15 @@ var _DataRow = _interopRequireDefault(require("./Components/DataRow"));
 
 var _Pagination = _interopRequireDefault(require("./Components/Pagination"));
 
+var _PerPage = _interopRequireDefault(require("./Components/PerPage"));
+
 var _flatten = _interopRequireDefault(require("core-js/fn/array/flatten"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -106,6 +108,7 @@ function (_Component) {
       checkedRows: []
     };
     _this.className = _this.className.bind(_assertThisInitialized(_this));
+    _this.changePerPage = _this.changePerPage.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -260,178 +263,6 @@ function (_Component) {
       return fields;
     }
   }, {
-    key: "render",
-    value: function render() {
-      var _this2 = this;
-
-      var _this$props3 = this.props,
-          errorMessage = _this$props3.errorMessage,
-          loading = _this$props3.loading,
-          rows = _this$props3.rows;
-      var fields = this.getFields();
-
-      if (errorMessage) {
-        return this.renderErrorTable();
-      }
-
-      if (loading) {
-        return this.renderLoadingTable();
-      }
-
-      if (!rows || !rows.length) {
-        return this.renderEmptyTable();
-      }
-
-      return _react["default"].createElement("div", null, _react["default"].createElement("div", {
-        className: "table-responsive"
-      }, _react["default"].createElement("table", {
-        className: this.className()
-      }, _react["default"].createElement("thead", null, _react["default"].createElement("tr", null, this.renderCheckboxCell('all'), fields.map(function (field) {
-        return _this2.renderHeader(field);
-      }), this.renderActionsCell())), _react["default"].createElement("tbody", null, rows.map(function (row, index) {
-        return _this2.renderRow(row, index);
-      })))), this.renderPagination());
-    }
-  }, {
-    key: "renderRow",
-    value: function renderRow(row, index) {
-      var _this3 = this;
-
-      var _this$props4 = this.props,
-          onClick = _this$props4.onClick,
-          onMouseUp = _this$props4.onMouseUp,
-          onMouseDown = _this$props4.onMouseDown,
-          buttons = _this$props4.buttons,
-          renderCheckboxes = _this$props4.renderCheckboxes,
-          disabledCheckboxes = _this$props4.disabledCheckboxes,
-          _dataItemManipulator = _this$props4.dataItemManipulator,
-          rowRenderer = _this$props4.rowRenderer,
-          dangerouslyRenderFields = _this$props4.dangerouslyRenderFields,
-          actions = _this$props4.actions,
-          editableColumns = _this$props4.editableColumns;
-      return rowRenderer({
-        row: row,
-        onClick: onClick,
-        onMouseUp: onMouseUp,
-        onMouseDown: onMouseDown,
-        buttons: buttons,
-        renderCheckboxes: renderCheckboxes,
-        disableCheckbox: disabledCheckboxes.includes(row.id),
-        key: row.id,
-        fields: this.getFields(),
-        dataItemManipulator: function dataItemManipulator(field, value, row) {
-          return _dataItemManipulator(field, value, row);
-        },
-        checkboxIsChecked: function checkboxIsChecked(value) {
-          return _this3.checkboxIsChecked(value);
-        },
-        onCheckboxChange: function onCheckboxChange(e) {
-          return _this3.checkboxChange(e, row);
-        },
-        dangerouslyRenderFields: dangerouslyRenderFields,
-        actions: actions,
-        editableColumns: editableColumns,
-        index: index
-      });
-    }
-  }, {
-    key: "renderHeader",
-    value: function renderHeader(field) {
-      var _this4 = this;
-
-      var _this$props5 = this.props,
-          orderByField = _this$props5.orderByField,
-          orderByDirection = _this$props5.orderByDirection,
-          orderByAscIcon = _this$props5.orderByAscIcon,
-          orderByDescIcon = _this$props5.orderByDescIcon,
-          allowOrderingBy = _this$props5.allowOrderingBy,
-          disallowOrderingBy = _this$props5.disallowOrderingBy,
-          changeOrder = _this$props5.changeOrder,
-          columnWidths = _this$props5.columnWidths;
-      var orderByIcon = '';
-
-      if (orderByField === field.name) {
-        if (orderByDirection === 'asc') {
-          orderByIcon = orderByAscIcon;
-        } else {
-          orderByIcon = orderByDescIcon;
-        }
-      }
-
-      var canOrderBy = (allowOrderingBy.length === 0 || allowOrderingBy.includes(field.name)) && !disallowOrderingBy.includes(field.name);
-      var onClickHandler = canOrderBy ? function () {
-        return _this4.changeOrder(field);
-      } : function () {};
-      var cursor = changeOrder && canOrderBy ? 'pointer' : 'default';
-      var width = columnWidths[field.name];
-
-      if (typeof width === 'number') {
-        width = "".concat(width, "%");
-      }
-
-      return _react["default"].createElement("th", {
-        key: field.name,
-        width: width,
-        onClick: onClickHandler,
-        style: {
-          cursor: cursor
-        }
-      }, field.label, "\xA0", orderByIcon);
-    }
-  }, {
-    key: "renderActionsCell",
-    value: function renderActionsCell() {
-      var _this5 = this;
-
-      var _this$props6 = this.props,
-          actions = _this$props6.actions,
-          buttons = _this$props6.buttons;
-      var state = this.state;
-
-      if (!buttons.length && !actions.length) {
-        return null;
-      } else if (!actions.length) {
-        return _react["default"].createElement("th", null);
-      }
-
-      return _react["default"].createElement("th", {
-        className: "rddt-action-cell"
-      }, _react["default"].createElement("div", {
-        className: "dropdown"
-      }, _react["default"].createElement("button", {
-        className: "btn btn-secondary dropdown-toggle",
-        type: "button",
-        id: "dropdownMenuButton",
-        "data-toggle": "dropdown",
-        "aria-haspopup": "true",
-        "aria-expanded": "false",
-        disabled: !state.checkedRows.length
-      }, "Actions"), _react["default"].createElement("div", {
-        className: "dropdown-menu",
-        "aria-labelledby": "dropdownMenuButton"
-      }, this.props.actions.map(function (action) {
-        return _this5.renderActionButton(action);
-      }))));
-    }
-  }, {
-    key: "renderActionButton",
-    value: function renderActionButton(action) {
-      var _this6 = this;
-
-      return _react["default"].createElement("button", {
-        key: "action_".concat(action.name),
-        type: "button",
-        className: "dropdown-item",
-        onClick: function onClick() {
-          action.callback(_this6.state.checkedRows);
-
-          _this6.setState({
-            checkedRows: []
-          });
-        }
-      }, action.name);
-    }
-  }, {
     key: "changeOrder",
     value: function changeOrder(field) {
       var props = this.props;
@@ -448,38 +279,23 @@ function (_Component) {
       props.changeOrder(field.name, newOrderByDirection);
     }
   }, {
-    key: "renderCheckboxCell",
-    value: function renderCheckboxCell(value) {
-      var _this7 = this;
+    key: "changePerPage",
+    value: function changePerPage(limit) {
+      var changePerPage = this.props.changePerPage;
 
-      if (!this.props.renderCheckboxes) {
+      if (!changePerPage) {
         return;
       }
 
-      var checkbox = _react["default"].createElement("div", {
-        className: "form-check"
-      }, _react["default"].createElement("input", {
-        type: "checkbox",
-        value: value,
-        checked: this.checkboxIsChecked(value),
-        onChange: function onChange(event) {
-          return _this7.checkboxChange(event, value);
-        }
-      }));
-
-      if (value === 'all') {
-        return _react["default"].createElement("th", null, checkbox);
-      }
-
-      return _react["default"].createElement("td", null, checkbox);
+      changePerPage(limit);
     }
   }, {
     key: "checkboxIsChecked",
     value: function checkboxIsChecked(row) {
       var checkedRows = this.state.checkedRows;
-      var _this$props7 = this.props,
-          rows = _this$props7.rows,
-          disabledCheckboxes = _this$props7.disabledCheckboxes;
+      var _this$props3 = this.props,
+          rows = _this$props3.rows,
+          disabledCheckboxes = _this$props3.disabledCheckboxes;
 
       if (row === 'all') {
         return checkedRows.length === rows.filter(function (_ref) {
@@ -505,9 +321,9 @@ function (_Component) {
   }, {
     key: "checkboxChange",
     value: function checkboxChange(event, row) {
-      var _this$props8 = this.props,
-          rows = _this$props8.rows,
-          disabledCheckboxes = _this$props8.disabledCheckboxes;
+      var _this$props4 = this.props,
+          rows = _this$props4.rows,
+          disabledCheckboxes = _this$props4.disabledCheckboxes;
       var target = event.target;
 
       if (row === 'all') {
@@ -557,6 +373,206 @@ function (_Component) {
       this.setState({
         checkedRows: checkedRows
       });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      var _this$props5 = this.props,
+          errorMessage = _this$props5.errorMessage,
+          loading = _this$props5.loading,
+          rows = _this$props5.rows;
+      var fields = this.getFields();
+
+      if (errorMessage) {
+        return this.renderErrorTable();
+      }
+
+      if (loading) {
+        return this.renderLoadingTable();
+      }
+
+      if (!rows || !rows.length) {
+        return this.renderEmptyTable();
+      }
+
+      return _react["default"].createElement("div", null, _react["default"].createElement("div", {
+        className: "table-responsive"
+      }, _react["default"].createElement("table", {
+        className: this.className()
+      }, _react["default"].createElement("thead", null, _react["default"].createElement("tr", null, this.renderCheckboxCell('all'), fields.map(function (field) {
+        return _this2.renderHeader(field);
+      }), this.renderActionsCell())), _react["default"].createElement("tbody", null, rows.map(function (row, index) {
+        return _this2.renderRow(row, index);
+      })))), _react["default"].createElement("div", {
+        className: 'd-flex justify-content-between align-items-center'
+      }, this.renderPerPage(), this.renderPagination()));
+    }
+  }, {
+    key: "renderRow",
+    value: function renderRow(row, index) {
+      var _this3 = this;
+
+      var _this$props6 = this.props,
+          onClick = _this$props6.onClick,
+          onMouseUp = _this$props6.onMouseUp,
+          onMouseDown = _this$props6.onMouseDown,
+          buttons = _this$props6.buttons,
+          renderCheckboxes = _this$props6.renderCheckboxes,
+          disabledCheckboxes = _this$props6.disabledCheckboxes,
+          _dataItemManipulator = _this$props6.dataItemManipulator,
+          rowRenderer = _this$props6.rowRenderer,
+          dangerouslyRenderFields = _this$props6.dangerouslyRenderFields,
+          actions = _this$props6.actions,
+          editableColumns = _this$props6.editableColumns;
+      return rowRenderer({
+        row: row,
+        onClick: onClick,
+        onMouseUp: onMouseUp,
+        onMouseDown: onMouseDown,
+        buttons: buttons,
+        renderCheckboxes: renderCheckboxes,
+        disableCheckbox: disabledCheckboxes.includes(row.id),
+        key: row.id,
+        fields: this.getFields(),
+        dataItemManipulator: function dataItemManipulator(field, value, row) {
+          return _dataItemManipulator(field, value, row);
+        },
+        checkboxIsChecked: function checkboxIsChecked(value) {
+          return _this3.checkboxIsChecked(value);
+        },
+        onCheckboxChange: function onCheckboxChange(e) {
+          return _this3.checkboxChange(e, row);
+        },
+        dangerouslyRenderFields: dangerouslyRenderFields,
+        actions: actions,
+        editableColumns: editableColumns,
+        index: index
+      });
+    }
+  }, {
+    key: "renderHeader",
+    value: function renderHeader(field) {
+      var _this4 = this;
+
+      var _this$props7 = this.props,
+          orderByField = _this$props7.orderByField,
+          orderByDirection = _this$props7.orderByDirection,
+          orderByAscIcon = _this$props7.orderByAscIcon,
+          orderByDescIcon = _this$props7.orderByDescIcon,
+          allowOrderingBy = _this$props7.allowOrderingBy,
+          disallowOrderingBy = _this$props7.disallowOrderingBy,
+          changeOrder = _this$props7.changeOrder,
+          columnWidths = _this$props7.columnWidths;
+      var orderByIcon = '';
+
+      if (orderByField === field.name) {
+        if (orderByDirection === 'asc') {
+          orderByIcon = orderByAscIcon;
+        } else {
+          orderByIcon = orderByDescIcon;
+        }
+      }
+
+      var canOrderBy = (allowOrderingBy.length === 0 || allowOrderingBy.includes(field.name)) && !disallowOrderingBy.includes(field.name);
+      var onClickHandler = canOrderBy ? function () {
+        return _this4.changeOrder(field);
+      } : function () {};
+      var cursor = changeOrder && canOrderBy ? 'pointer' : 'default';
+      var width = columnWidths[field.name];
+
+      if (typeof width === 'number') {
+        width = "".concat(width, "%");
+      }
+
+      return _react["default"].createElement("th", {
+        key: field.name,
+        width: width,
+        onClick: onClickHandler,
+        style: {
+          cursor: cursor
+        }
+      }, field.label, "\xA0", orderByIcon);
+    }
+  }, {
+    key: "renderActionsCell",
+    value: function renderActionsCell() {
+      var _this5 = this;
+
+      var _this$props8 = this.props,
+          actions = _this$props8.actions,
+          buttons = _this$props8.buttons;
+      var state = this.state;
+
+      if (!buttons.length && !actions.length) {
+        return null;
+      } else if (!actions.length) {
+        return _react["default"].createElement("th", null);
+      }
+
+      return _react["default"].createElement("th", {
+        className: "rddt-action-cell"
+      }, _react["default"].createElement("div", {
+        className: "dropdown"
+      }, _react["default"].createElement("button", {
+        className: "btn btn-secondary dropdown-toggle",
+        type: "button",
+        id: "dropdownMenuButton",
+        "data-toggle": "dropdown",
+        "aria-haspopup": "true",
+        "aria-expanded": "false",
+        disabled: !state.checkedRows.length
+      }, "Actions"), _react["default"].createElement("div", {
+        className: "dropdown-menu",
+        "aria-labelledby": "dropdownMenuButton"
+      }, this.props.actions.map(function (action) {
+        return _this5.renderActionButton(action);
+      }))));
+    }
+  }, {
+    key: "renderActionButton",
+    value: function renderActionButton(action) {
+      var _this6 = this;
+
+      return _react["default"].createElement("button", {
+        key: "action_".concat(action.name),
+        type: "button",
+        className: "dropdown-item",
+        onClick: function onClick() {
+          action.callback(_this6.state.checkedRows);
+
+          _this6.setState({
+            checkedRows: []
+          });
+        }
+      }, action.name);
+    }
+  }, {
+    key: "renderCheckboxCell",
+    value: function renderCheckboxCell(value) {
+      var _this7 = this;
+
+      if (!this.props.renderCheckboxes) {
+        return;
+      }
+
+      var checkbox = _react["default"].createElement("div", {
+        className: "form-check"
+      }, _react["default"].createElement("input", {
+        type: "checkbox",
+        value: value,
+        checked: this.checkboxIsChecked(value),
+        onChange: function onChange(event) {
+          return _this7.checkboxChange(event, value);
+        }
+      }));
+
+      if (value === 'all') {
+        return _react["default"].createElement("th", null, checkbox);
+      }
+
+      return _react["default"].createElement("td", null, checkbox);
     }
   }, {
     key: "renderLoadingTable",
@@ -620,6 +636,34 @@ function (_Component) {
         },
         paginationDelta: props.paginationDelta
       });
+    }
+  }, {
+    key: "renderPerPage",
+    value: function renderPerPage() {
+      var _this$props11 = this.props,
+          changePerPage = _this$props11.changePerPage,
+          totalRows = _this$props11.totalRows,
+          perPage = _this$props11.perPage,
+          perPageRenderer = _this$props11.perPageRenderer;
+      var props = {
+        totalRows: totalRows,
+        value: perPage,
+        onChange: this.changePerPage
+      };
+
+      if (!changePerPage) {
+        return;
+      }
+
+      if (typeof perPageRenderer === 'function') {
+        return perPageRenderer(props);
+      }
+
+      if (_react["default"].isValidElement(perPageRenderer)) {
+        return _react["default"].cloneElement(perPageRenderer, props);
+      }
+
+      return perPageRenderer;
     }
   }], [{
     key: "noop",
@@ -709,7 +753,11 @@ DynamicDataTable.propTypes = {
   disallowOrderingBy: _propTypes["default"].array,
   dangerouslyRenderFields: _propTypes["default"].array,
   paginationDelta: _propTypes["default"].number,
-  columnWidths: _propTypes["default"].object
+  columnWidths: _propTypes["default"].object,
+  totalRows: _propTypes["default"].number,
+  changePerPage: _propTypes["default"].func,
+  perPage: _propTypes["default"].oneOfType([_propTypes["default"].number, _propTypes["default"].string]),
+  perPageRenderer: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].func])
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -751,7 +799,13 @@ DynamicDataTable.defaultProps = {
   disallowOrderingBy: [],
   dangerouslyRenderFields: [],
   paginationDelta: 4,
-  columnWidths: {}
+  columnWidths: {},
+  totalRows: 0,
+  changePerPage: null,
+  perPage: 15,
+  perPageRenderer: function perPageRenderer(props) {
+    return _react["default"].createElement(_PerPage["default"], props);
+  }
 };
 var _default = DynamicDataTable;
 exports["default"] = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import DynamicDataTable from "./DynamicDataTable";
+
+import DynamicDataTable from './DynamicDataTable';
 
 class AjaxDynamicDataTable extends Component {
 
@@ -11,7 +12,9 @@ class AjaxDynamicDataTable extends Component {
         this.state = {
             rows: [],
             currentPage: 1,
+            perPage: 15,
             totalPages: 1,
+            totalRows: 0,
             orderByField: defaultOrderByField,
             orderByDirection: defaultOrderByDirection,
             disallowOrderingBy: [],
@@ -19,8 +22,10 @@ class AjaxDynamicDataTable extends Component {
         };
 
         this.reload = this.reload.bind(this);
+
         this.changePage = this.changePage.bind(this);
         this.changeOrder = this.changeOrder.bind(this);
+        this.changePerPage = this.changePerPage.bind(this);
     }
 
     componentDidMount() {
@@ -52,19 +57,22 @@ class AjaxDynamicDataTable extends Component {
 
     render() {
 
-        const { rows, currentPage, totalPages, orderByField, orderByDirection } = this.state;
+        const { rows, totalRows, currentPage, perPage, totalPages, orderByField, orderByDirection } = this.state;
         const { disallowOrderingBy, ...props } = this.props;
 
         return (
             <DynamicDataTable
                 rows={rows}
+                totalRows={totalRows}
                 currentPage={currentPage}
+                perPage={perPage}
                 totalPages={totalPages}
                 orderByField={orderByField}
                 orderByDirection={orderByDirection}
                 loading={this.loading}
                 changePage={this.changePage}
                 changeOrder={this.changeOrder}
+                changePerPage={this.changePerPage}
                 disallowOrderingBy={this.disallowOrderingBy}
                 {...props}
             />
@@ -76,7 +84,7 @@ class AjaxDynamicDataTable extends Component {
     }
 
     loadPage(page) {
-        const {orderByField, orderByDirection} = this.state;
+        const {perPage, orderByField, orderByDirection} = this.state;
         const {onLoad, params, axios} = this.props;
 
         this.setState(
@@ -84,11 +92,11 @@ class AjaxDynamicDataTable extends Component {
             () => {
                 axios.get(this.props.apiUrl, {
 
-                    params: { ...params, page, orderByField, orderByDirection }
+                    params: { ...params, page, perPage, orderByField, orderByDirection }
 
                 }).then(({ data: response }) => {
 
-                    const { data: rows, current_page, last_page } = response.data;
+                    const { data: rows, total, current_page, last_page } = response.data;
                     let disallow_ordering_by = [];
 
                     if (response.meta) {
@@ -98,6 +106,7 @@ class AjaxDynamicDataTable extends Component {
                     const newState = {
                         disallowOrderingBy: disallow_ordering_by,
                         rows,
+                        totalRows: total,
                         currentPage: current_page,
                         totalPages:last_page,
                         loading: false
@@ -112,6 +121,13 @@ class AjaxDynamicDataTable extends Component {
 
     changePage(page) {
         this.loadPage(page)
+    }
+
+    changePerPage(limit) {
+        this.setState(
+            { perPage: limit },
+            this.reload
+        )
     }
 
     changeOrder(field, direction) {

--- a/src/Components/DataRow.jsx
+++ b/src/Components/DataRow.jsx
@@ -233,7 +233,7 @@ DataRow.propTypes = {
     onMouseDown: PropTypes.func,
     onContextMenu: PropTypes.func,
     dangerouslyRenderFields: PropTypes.array,
-    index: PropTypes.number.required,
+    index: PropTypes.number.isRequired,
 };
 
 export default DataRow;

--- a/src/Components/Pagination.jsx
+++ b/src/Components/Pagination.jsx
@@ -30,8 +30,8 @@ class Pagination extends Component {
         });
 
         return (
-            <nav aria-label="Page navigation">
-                <ul className="pagination">
+            <nav aria-label="Page navigation ml-auto">
+                <ul className="pagination mb-0">
                     <li className={`page-item ${currentPage <= 1 ? 'disabled' : ''}`}>
                         <button type="button" className="page-link" onClick={() => this.previousPage()}>Previous</button>
                     </li>

--- a/src/Components/PerPage.jsx
+++ b/src/Components/PerPage.jsx
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class PerPage extends Component {
+    constructor(props) {
+        super(props);
+
+        this.onChange = this.onChange.bind(this);
+    }
+
+    onChange({ target: { value } }) {
+        const { onChange } = this.props;
+
+        onChange(value)
+    }
+
+    render() {
+        const { className: { container, innerContainer, select }, value, defaultValue, options, totalRows } = this.props;
+
+        return (
+            <div className={container}>
+                <span>Showing</span>
+                <div className={innerContainer}>
+                    <select
+                        className={select}
+                        value={value || defaultValue}
+                        onChange={this.onChange}
+                    >
+                        {options.map(option => (
+                            <option key={option} value={option}>
+                                {option}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <span>of {totalRows} records</span>
+            </div>
+        )
+    }
+}
+
+PerPage.defaultProps = {
+    className: {
+        container: 'd-flex align-items-center',
+        innerContainer: 'form-group mb-0 mx-sm-3 mx-2',
+        select: 'form-control',
+    },
+    defaultValue: 15,
+    options: [
+        10, 15, 30,
+        50, 75, 100
+    ],
+}
+
+PerPage.propTypes = {
+    onChange: PropTypes.func.isRequired,
+    totalRows: PropTypes.number.isRequired,
+    value: (
+        PropTypes
+            .oneOfType([PropTypes.number, PropTypes.string])
+            .isRequired
+    ),
+    defaultValue: (
+        PropTypes.oneOfType([
+            PropTypes.number, PropTypes.string,
+        ])
+    ),
+    className: (
+        PropTypes.shape({
+            container: PropTypes.string,
+            innerContainer: PropTypes.string,
+            select: PropTypes.string,
+        })
+    ),
+    options: PropTypes.arrayOf(PropTypes.number),
+}
+
+export default PerPage;


### PR DESCRIPTION
This PR implements a reworked [`pageLimitRenderer`](https://github.com/langleyfoxall/react-dynamic-data-table/pull/63) now named `perPageRenderer`.

Basic implementation is described in the new section of documentation "Per page limiting".
```jsx
<DynamicDataTable
    totalRows={totalRows}
    perPage={perPage}
    changePerPage={newPerPage => (
        this.setState({
            perPage: newPerPage
        })
    )}
    perPageRenderer={props => (
        <PerPage {...props} />
    )}
/>
```

By default only `totalRows`, `perPage` and `changePerPage` are needed. The per page limiter will only be rendered if `changePerPage` is truthy.

---

#### New:

##### Components:
* `Pagination`
  * Minor margin changes
* `PerPage`
  * New component that is a Bootstrap styled select used for changing the per page limit

##### Props:
* `totalRows`: Total number of rows in the dataset
* `perPage`: The current per page limit
* `perPageRenderer`: A node or function for rendering a limiter
* `changePerPage`: A callback expecting a single argument

#### Fixes:

* `DataRow`'s `index` prop type

---

This functionality is required for several tickets for a project in development.