### PR TITLE
Automatically append meta to footer data

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -17,6 +17,10 @@ require("core-js/modules/es7.symbol.async-iterator");
 
 require("core-js/modules/es6.array.is-array");
 
+require("core-js/modules/es6.object.assign");
+
+require("core-js/modules/es6.array.index-of");
+
 require("core-js/modules/es6.object.define-properties");
 
 require("core-js/modules/es7.object.get-own-property-descriptors");
@@ -25,11 +29,7 @@ require("core-js/modules/es6.array.for-each");
 
 require("core-js/modules/es6.array.filter");
 
-require("core-js/modules/es6.object.assign");
-
 require("core-js/modules/es6.symbol");
-
-require("core-js/modules/es6.array.index-of");
 
 require("core-js/modules/web.dom.iterable");
 
@@ -79,17 +79,17 @@ function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToAr
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -133,12 +133,14 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
       orderByField: defaultOrderByField,
       orderByDirection: defaultOrderByDirection,
       disallowOrderingBy: [],
+      meta: {},
       loading: false
     };
     _this.reload = _this.reload.bind(_assertThisInitialized(_this));
     _this.changePage = _this.changePage.bind(_assertThisInitialized(_this));
     _this.changeOrder = _this.changeOrder.bind(_assertThisInitialized(_this));
     _this.changePerPage = _this.changePerPage.bind(_assertThisInitialized(_this));
+    _this.renderFooter = _this.renderFooter.bind(_assertThisInitialized(_this));
     return _this;
   }
 
@@ -155,6 +157,20 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
       }
     }
   }, {
+    key: "renderFooter",
+    value: function renderFooter(args) {
+      var meta = this.state.meta;
+      var footer = this.props.footer;
+
+      if (typeof footer === 'function') {
+        return footer(_objectSpread({
+          meta: meta
+        }, args));
+      }
+
+      return footer;
+    }
+  }, {
     key: "render",
     value: function render() {
       var _this$state = this.state,
@@ -168,7 +184,8 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
 
       var _this$props = this.props,
           disallowOrderingBy = _this$props.disallowOrderingBy,
-          props = _objectWithoutProperties(_this$props, ["disallowOrderingBy"]);
+          footer = _this$props.footer,
+          props = _objectWithoutProperties(_this$props, ["disallowOrderingBy", "footer"]);
 
       return /*#__PURE__*/_react["default"].createElement(_DynamicDataTable["default"], _extends({
         rows: rows,
@@ -182,7 +199,8 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
         changePage: this.changePage,
         changeOrder: this.changeOrder,
         changePerPage: this.changePerPage,
-        disallowOrderingBy: this.disallowOrderingBy
+        disallowOrderingBy: this.disallowOrderingBy,
+        footer: footer ? this.renderFooter : undefined
       }, props));
     }
   }, {
@@ -222,14 +240,19 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
               current_page = _response$data.current_page,
               last_page = _response$data.last_page;
           var disallow_ordering_by = [];
+          var meta = {};
 
           if (response.meta) {
-            disallow_ordering_by = response.meta.disallow_ordering_by;
+            var _response$meta = response.meta;
+            disallow_ordering_by = _response$meta.disallow_ordering_by;
+            meta = _objectWithoutProperties(_response$meta, ["disallow_ordering_by"]);
+            _response$meta;
           }
 
           var newState = {
-            disallowOrderingBy: disallow_ordering_by,
             rows: rows,
+            meta: meta,
+            disallowOrderingBy: disallow_ordering_by,
             totalRows: total,
             currentPage: current_page,
             totalPages: last_page,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.12.0",
+  "version": "7.13.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -18,6 +18,7 @@ class AjaxDynamicDataTable extends Component {
             orderByField: defaultOrderByField,
             orderByDirection: defaultOrderByDirection,
             disallowOrderingBy: [],
+            meta: {},
             loading: false,
         };
 
@@ -26,6 +27,8 @@ class AjaxDynamicDataTable extends Component {
         this.changePage = this.changePage.bind(this);
         this.changeOrder = this.changeOrder.bind(this);
         this.changePerPage = this.changePerPage.bind(this);
+
+        this.renderFooter = this.renderFooter.bind(this);
     }
 
     componentDidMount() {
@@ -55,10 +58,21 @@ class AjaxDynamicDataTable extends Component {
         ];
     }
 
+    renderFooter(args) {
+        const { meta } = this.state;
+        const { footer } = this.props;
+
+        if (typeof footer === 'function') {
+            return footer({ meta, ...args })
+        }
+
+        return footer
+    }
+
     render() {
 
         const { rows, totalRows, currentPage, perPage, totalPages, orderByField, orderByDirection } = this.state;
-        const { disallowOrderingBy, ...props } = this.props;
+        const { disallowOrderingBy, footer, ...props } = this.props;
 
         return (
             <DynamicDataTable
@@ -74,6 +88,7 @@ class AjaxDynamicDataTable extends Component {
                 changeOrder={this.changeOrder}
                 changePerPage={this.changePerPage}
                 disallowOrderingBy={this.disallowOrderingBy}
+                footer={footer ? this.renderFooter : undefined}
                 {...props}
             />
         );
@@ -98,14 +113,16 @@ class AjaxDynamicDataTable extends Component {
 
                     const { data: rows, total, current_page, last_page } = response.data;
                     let disallow_ordering_by = [];
+                    let meta = {}
 
                     if (response.meta) {
-                        ({ disallow_ordering_by } = response.meta);
+                        ({ disallow_ordering_by, ...meta } = response.meta);
                     }
 
                     const newState = {
-                        disallowOrderingBy: disallow_ordering_by,
                         rows,
+                        meta,
+                        disallowOrderingBy: disallow_ordering_by,
                         totalRows: total,
                         currentPage: current_page,
                         totalPages:last_page,
@@ -146,7 +163,7 @@ AjaxDynamicDataTable.defaultProps = {
     params: {},
     defaultOrderByField: null,
     defaultOrderByDirection: null,
-    axios: typeof window !== 'undefined' && window.axios 
+    axios: typeof window !== 'undefined' && window.axios
         ? window.axios : require('axios'),
     disallowOrderingBy: [],
 };


### PR DESCRIPTION
When using the `AjaxDynamicDataTable` I have wrapped the `footer` prop within `renderFooter` which will add a `meta` attribute to the data passed to `footer` when called as a function.

This feature would be useful when calculating totals or similar on the server and passing them down into the footer.

Usage does not change, it just "magically" appears:
```jsx
<AjaxDynamicDataTable
  footer={({ meta: { total }, width }) => (
    <tr>
      <td colSpan={width}>
        Total number of sales {total}
      </td>
    </tr>
  )}
/>
```

---

Unfortunately, I feel like a separate PR is needed to overhaul the documentation. Splitting off into separate files and start documenting the `AjaxDynamicDataTable`.

This has been briefly discussed between myself and @DivineOmega.