### PR TITLE
Allow for AjaxDynamicDataTable to accept a perPage prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Changing the number of entries displaying in the data table is easy. The `totalR
 * `totalRows` the total number of rows within the dataset
 * `perPage` the current per page limit (default: `15`)
 * `changePerPage` handles the logic for changing the `perPage` prop. This recieved a single argument which is the new limit.
+* `perPageOptions` the results per page options (default: `[10, 15, 30, 50, 75, 100]`)
 * `perPageRender` can either be a node or a function.
 
 By default a Bootstrap styled select is displayed if `changePerPage` is a function.
@@ -331,6 +332,7 @@ The `perPageRenderer` prop accepts either a node or function. If a valid react e
 * `totalRows`
 * `value` (see `perPage` above)
 * `onChange` (see `changePerPage` above)
+* `perPageOptions`
 
 If a function is passed then the props described above are passed in an object.
 

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -123,11 +123,12 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
 
     _this = _super.call(this, props);
     var defaultOrderByField = props.defaultOrderByField,
-        defaultOrderByDirection = props.defaultOrderByDirection;
+        defaultOrderByDirection = props.defaultOrderByDirection,
+        perPage = props.perPage;
     _this.state = {
       rows: [],
       currentPage: 1,
-      perPage: 15,
+      perPage: perPage,
       totalPages: 1,
       totalRows: 0,
       orderByField: defaultOrderByField,
@@ -177,7 +178,6 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
           rows = _this$state.rows,
           totalRows = _this$state.totalRows,
           currentPage = _this$state.currentPage,
-          perPage = _this$state.perPage,
           totalPages = _this$state.totalPages,
           orderByField = _this$state.orderByField,
           orderByDirection = _this$state.orderByDirection;
@@ -185,13 +185,14 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
       var _this$props = this.props,
           disallowOrderingBy = _this$props.disallowOrderingBy,
           footer = _this$props.footer,
-          props = _objectWithoutProperties(_this$props, ["disallowOrderingBy", "footer"]);
+          perPage = _this$props.perPage,
+          props = _objectWithoutProperties(_this$props, ["disallowOrderingBy", "footer", "perPage"]);
 
       return /*#__PURE__*/_react["default"].createElement(_DynamicDataTable["default"], _extends({
         rows: rows,
         totalRows: totalRows,
         currentPage: currentPage,
-        perPage: perPage,
+        perPage: this.state.perPage,
         totalPages: totalPages,
         orderByField: orderByField,
         orderByDirection: orderByDirection,
@@ -317,7 +318,8 @@ AjaxDynamicDataTable.defaultProps = {
   defaultOrderByField: null,
   defaultOrderByDirection: null,
   axios: typeof window !== 'undefined' && window.axios ? window.axios : require('axios'),
-  disallowOrderingBy: []
+  disallowOrderingBy: [],
+  perPage: 15
 };
 AjaxDynamicDataTable.propTypes = {
   apiUrl: _propTypes["default"].string,
@@ -327,7 +329,9 @@ AjaxDynamicDataTable.propTypes = {
   defaultOrderByField: _propTypes["default"].string,
   defaultOrderByDirection: _propTypes["default"].string,
   axios: _propTypes["default"].any,
-  disallowOrderingBy: _propTypes["default"].arrayOf(_propTypes["default"].string)
+  disallowOrderingBy: _propTypes["default"].arrayOf(_propTypes["default"].string),
+  perPage: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].number]),
+  perPageOptions: _propTypes["default"].arrayOf(_propTypes["default"].number)
 };
 var _default = AjaxDynamicDataTable;
 exports["default"] = _default;

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -711,12 +711,14 @@ var DynamicDataTable = /*#__PURE__*/function (_Component) {
       var _this$props12 = this.props,
           changePerPage = _this$props12.changePerPage,
           totalRows = _this$props12.totalRows,
+          perPageOptions = _this$props12.perPageOptions,
           perPage = _this$props12.perPage,
           perPageRenderer = _this$props12.perPageRenderer;
       var props = {
         totalRows: totalRows,
         value: perPage,
-        onChange: this.changePerPage
+        onChange: this.changePerPage,
+        options: perPageOptions
       };
 
       if (!changePerPage) {
@@ -825,6 +827,7 @@ DynamicDataTable.propTypes = {
   totalRows: _propTypes["default"].number,
   changePerPage: _propTypes["default"].func,
   perPage: _propTypes["default"].oneOfType([_propTypes["default"].number, _propTypes["default"].string]),
+  perPageOptions: _propTypes["default"].arrayOf(_propTypes["default"].number),
   perPageRenderer: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].func]),
   isCheckboxChecked: _propTypes["default"].func,
   onMasterCheckboxChange: _propTypes["default"].func,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.14.0",
+  "version": "7.15.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -7,12 +7,12 @@ class AjaxDynamicDataTable extends Component {
 
     constructor(props) {
         super(props);
-        const { defaultOrderByField, defaultOrderByDirection } = props;
+        const { defaultOrderByField, defaultOrderByDirection, perPage } = props;
 
         this.state = {
             rows: [],
             currentPage: 1,
-            perPage: 15,
+            perPage,
             totalPages: 1,
             totalRows: 0,
             orderByField: defaultOrderByField,
@@ -71,15 +71,15 @@ class AjaxDynamicDataTable extends Component {
 
     render() {
 
-        const { rows, totalRows, currentPage, perPage, totalPages, orderByField, orderByDirection } = this.state;
-        const { disallowOrderingBy, footer, ...props } = this.props;
+        const { rows, totalRows, currentPage, totalPages, orderByField, orderByDirection } = this.state;
+        const { disallowOrderingBy, footer, perPage, ...props } = this.props;
 
         return (
             <DynamicDataTable
                 rows={rows}
                 totalRows={totalRows}
                 currentPage={currentPage}
-                perPage={perPage}
+                perPage={this.state.perPage}
                 totalPages={totalPages}
                 orderByField={orderByField}
                 orderByDirection={orderByDirection}
@@ -166,6 +166,7 @@ AjaxDynamicDataTable.defaultProps = {
     axios: typeof window !== 'undefined' && window.axios
         ? window.axios : require('axios'),
     disallowOrderingBy: [],
+    perPage: 15,
 };
 
 AjaxDynamicDataTable.propTypes = {
@@ -177,6 +178,11 @@ AjaxDynamicDataTable.propTypes = {
     defaultOrderByDirection: PropTypes.string,
     axios: PropTypes.any,
     disallowOrderingBy: PropTypes.arrayOf(PropTypes.string),
+    perPage: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]),
+    perPageOptions: PropTypes.arrayOf(PropTypes.number),
 };
 
 export default AjaxDynamicDataTable;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -623,11 +623,13 @@ class DynamicDataTable extends Component {
     }
 
     renderPerPage() {
-        const { changePerPage, totalRows, perPage, perPageRenderer } = this.props;
+        const { changePerPage, totalRows, perPageOptions, perPage, perPageRenderer } = this.props;
+
         const props = {
             totalRows,
             value: perPage,
             onChange: this.changePerPage,
+            options: perPageOptions,
         };
 
         if (!changePerPage) {
@@ -702,6 +704,7 @@ DynamicDataTable.propTypes = {
     perPage: PropTypes.oneOfType([
         PropTypes.number, PropTypes.string,
     ]),
+    perPageOptions: PropTypes.arrayOf(PropTypes.number),
     perPageRenderer: PropTypes.oneOfType([
         PropTypes.node, PropTypes.func,
     ]),


### PR DESCRIPTION
I happened to notice that it wasn't possible to override the per page default or per page options when using the AjaxDynamicDataTable component.

There should be no breaking changes as a result of this PR.

# Changes:
- The AjaxDynamicDataTable component now accepts a perPage prop.
- The DynamicDataTable component now accepts a perPageOptions prop which it will pass down to the perPageRenderer.