### PR TITLE
Allow errors in AJAX requests issued by the AjaxDynamicDataTable to be captured

### DIFF
--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -221,6 +221,7 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
           orderByDirection = _this$state2.orderByDirection;
       var _this$props2 = this.props,
           onLoad = _this$props2.onLoad,
+          onError = _this$props2.onError,
           params = _this$props2.params,
           axios = _this$props2.axios;
       this.setState({
@@ -263,6 +264,12 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
           _this2.setState(newState);
 
           onLoad(newState);
+        })["catch"](function (e) {
+          _this2.setState({
+            loading: false
+          });
+
+          onError(e);
         });
       });
     }
@@ -313,6 +320,9 @@ AjaxDynamicDataTable.defaultProps = {
   onLoad: function onLoad() {
     return null;
   },
+  onError: function onError() {
+    return null;
+  },
   loading: false,
   params: {},
   defaultOrderByField: null,
@@ -324,6 +334,7 @@ AjaxDynamicDataTable.defaultProps = {
 AjaxDynamicDataTable.propTypes = {
   apiUrl: _propTypes["default"].string,
   onLoad: _propTypes["default"].func,
+  onError: _propTypes["default"].func,
   loading: _propTypes["default"].bool,
   params: _propTypes["default"].object,
   defaultOrderByField: _propTypes["default"].string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.16.0",
+  "version": "7.17.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/AjaxDynamicDataTable.jsx
+++ b/src/AjaxDynamicDataTable.jsx
@@ -100,7 +100,7 @@ class AjaxDynamicDataTable extends Component {
 
     loadPage(page) {
         const {perPage, orderByField, orderByDirection} = this.state;
-        const {onLoad, params, axios} = this.props;
+        const {onLoad, onError, params, axios} = this.props;
 
         this.setState(
             { loading: true },
@@ -131,6 +131,12 @@ class AjaxDynamicDataTable extends Component {
 
                     this.setState(newState);
                     onLoad(newState);
+
+                }).catch((e) => {
+
+                    this.setState({ loading: false });
+                    onError(e);
+
                 });
             }
         );
@@ -159,6 +165,7 @@ class AjaxDynamicDataTable extends Component {
 
 AjaxDynamicDataTable.defaultProps = {
     onLoad: () => null,
+    onError: () => null,
     loading: false,
     params: {},
     defaultOrderByField: null,
@@ -172,6 +179,7 @@ AjaxDynamicDataTable.defaultProps = {
 AjaxDynamicDataTable.propTypes = {
     apiUrl: PropTypes.string,
     onLoad: PropTypes.func,
+    onError: PropTypes.func,
     loading: PropTypes.bool,
     params: PropTypes.object,
     defaultOrderByField: PropTypes.string,


### PR DESCRIPTION
This PR allow errors in AJAX requests issued by the AjaxDynamicDataTable to be captured via an `onError` prop passed.