### PR TITLE
Feature to always show pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,16 @@ This delta can be changed by passing a `paginationDelta` prop into `DynamicDataT
     />
 ```
 
+### Always showing pagination controls
+
+By default the pagination controls are only shown if there are two or more pages of data to be displayed. You can override this behaviour by simply passing the `alwaysShowPagination` prop:
+
+```JSX
+<DynamicDataTable
+        alwaysShowPagination
+    />
+```
+
 ### Per page limiting
 
 Changing the number of entries displaying in the data table is easy. The `totalRows`, `perPage`, `changePerPage` and `perPageRenderer` allow you to customize a per page limit control.

--- a/dist/AjaxDynamicDataTable.js
+++ b/dist/AjaxDynamicDataTable.js
@@ -1,59 +1,57 @@
 "use strict";
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-require("core-js/modules/es6.reflect.construct.js");
-
-require("core-js/modules/es6.object.create.js");
-
-require("core-js/modules/es6.object.define-property.js");
-
-require("core-js/modules/es6.array.is-array.js");
-
-require("core-js/modules/es6.symbol.js");
-
-require("core-js/modules/es6.string.iterator.js");
-
-require("core-js/modules/es6.object.to-string.js");
-
-require("core-js/modules/es6.array.iterator.js");
-
-require("core-js/modules/web.dom.iterable.js");
-
-require("core-js/modules/es6.array.from.js");
-
-require("core-js/modules/es6.array.slice.js");
-
-require("core-js/modules/es6.function.name.js");
-
-require("core-js/modules/es6.object.keys.js");
-
-require("core-js/modules/es6.array.filter.js");
-
-require("core-js/modules/es6.object.get-own-property-descriptor.js");
-
-require("core-js/modules/es6.array.for-each.js");
-
-require("core-js/modules/es7.object.get-own-property-descriptors.js");
-
-require("core-js/modules/es6.object.define-properties.js");
-
-require("core-js/modules/es6.array.index-of.js");
-
-require("core-js/modules/es6.object.assign.js");
-
-require("core-js/modules/es6.weak-map.js");
+require("core-js/modules/es6.weak-map");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
 
-require("core-js/modules/es6.function.bind.js");
+require("core-js/modules/es6.function.name");
 
-require("core-js/modules/es6.object.set-prototype-of.js");
+require("core-js/modules/es6.string.iterator");
 
-require("core-js/modules/es6.object.get-prototype-of.js");
+require("core-js/modules/es6.array.from");
+
+require("core-js/modules/es7.symbol.async-iterator");
+
+require("core-js/modules/es6.array.is-array");
+
+require("core-js/modules/es6.object.assign");
+
+require("core-js/modules/es6.array.index-of");
+
+require("core-js/modules/es6.object.define-properties");
+
+require("core-js/modules/es7.object.get-own-property-descriptors");
+
+require("core-js/modules/es6.array.for-each");
+
+require("core-js/modules/es6.array.filter");
+
+require("core-js/modules/es6.symbol");
+
+require("core-js/modules/web.dom.iterable");
+
+require("core-js/modules/es6.array.iterator");
+
+require("core-js/modules/es6.object.keys");
+
+require("core-js/modules/es6.object.define-property");
+
+require("core-js/modules/es6.object.create");
+
+require("core-js/modules/es6.regexp.to-string");
+
+require("core-js/modules/es6.date.to-string");
+
+require("core-js/modules/es6.object.to-string");
+
+require("core-js/modules/es6.reflect.construct");
+
+require("core-js/modules/es6.object.set-prototype-of");
+
+require("core-js/modules/es6.function.bind");
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -61,26 +59,13 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _DynamicDataTable = _interopRequireDefault(require("./DynamicDataTable"));
 
-var _excluded = ["disallowOrderingBy", "footer", "perPage"],
-    _excluded2 = ["disallow_ordering_by"];
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-
-function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
-
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
 
@@ -88,11 +73,23 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -110,7 +107,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -161,20 +158,6 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
       }
     }
   }, {
-    key: "loading",
-    get: function get() {
-      var state = this.state.loading;
-      var prop = this.props.loading;
-      return state || prop;
-    }
-  }, {
-    key: "disallowOrderingBy",
-    get: function get() {
-      var state = this.state.disallowOrderingBy;
-      var prop = this.props.disallowOrderingBy;
-      return [].concat(_toConsumableArray(state), _toConsumableArray(prop));
-    }
-  }, {
     key: "renderFooter",
     value: function renderFooter(args) {
       var meta = this.state.meta;
@@ -203,9 +186,9 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
           disallowOrderingBy = _this$props.disallowOrderingBy,
           footer = _this$props.footer,
           perPage = _this$props.perPage,
-          props = _objectWithoutProperties(_this$props, _excluded);
+          props = _objectWithoutProperties(_this$props, ["disallowOrderingBy", "footer", "perPage"]);
 
-      return _react["default"].createElement(_DynamicDataTable["default"], _extends({
+      return /*#__PURE__*/_react["default"].createElement(_DynamicDataTable["default"], _extends({
         rows: rows,
         totalRows: totalRows,
         currentPage: currentPage,
@@ -264,7 +247,7 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
           if (response.meta) {
             var _response$meta = response.meta;
             disallow_ordering_by = _response$meta.disallow_ordering_by;
-            meta = _objectWithoutProperties(_response$meta, _excluded2);
+            meta = _objectWithoutProperties(_response$meta, ["disallow_ordering_by"]);
             _response$meta;
           }
 
@@ -313,6 +296,20 @@ var AjaxDynamicDataTable = /*#__PURE__*/function (_Component) {
       }, function () {
         _this3.loadPage(1);
       });
+    }
+  }, {
+    key: "loading",
+    get: function get() {
+      var state = this.state.loading;
+      var prop = this.props.loading;
+      return state || prop;
+    }
+  }, {
+    key: "disallowOrderingBy",
+    get: function get() {
+      var state = this.state.disallowOrderingBy;
+      var prop = this.props.disallowOrderingBy;
+      return [].concat(_toConsumableArray(state), _toConsumableArray(prop));
     }
   }]);
 

--- a/dist/Components/DataRow.js
+++ b/dist/Components/DataRow.js
@@ -1,43 +1,45 @@
 "use strict";
 
-require("core-js/modules/es6.reflect.construct.js");
+require("core-js/modules/web.dom.iterable");
 
-require("core-js/modules/es6.object.create.js");
+require("core-js/modules/es6.array.iterator");
 
-require("core-js/modules/es6.object.define-property.js");
+require("core-js/modules/es6.string.iterator");
 
-require("core-js/modules/es6.symbol.js");
-
-require("core-js/modules/es6.string.iterator.js");
-
-require("core-js/modules/es6.object.to-string.js");
-
-require("core-js/modules/es6.array.iterator.js");
-
-require("core-js/modules/web.dom.iterable.js");
-
-require("core-js/modules/es6.weak-map.js");
-
-require("core-js/modules/es6.object.get-own-property-descriptor.js");
+require("core-js/modules/es6.weak-map");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
 
-require("core-js/modules/es6.string.includes.js");
+require("core-js/modules/es7.symbol.async-iterator");
 
-require("core-js/modules/es7.array.includes.js");
+require("core-js/modules/es6.symbol");
 
-require("core-js/modules/es6.array.map.js");
+require("core-js/modules/es6.object.define-property");
 
-require("core-js/modules/es6.function.name.js");
+require("core-js/modules/es6.object.create");
 
-require("core-js/modules/es6.array.find-index.js");
+require("core-js/modules/es6.regexp.to-string");
 
-require("core-js/modules/es6.object.set-prototype-of.js");
+require("core-js/modules/es6.date.to-string");
 
-require("core-js/modules/es6.object.get-prototype-of.js");
+require("core-js/modules/es6.object.to-string");
+
+require("core-js/modules/es6.reflect.construct");
+
+require("core-js/modules/es6.object.set-prototype-of");
+
+require("core-js/modules/es6.array.find-index");
+
+require("core-js/modules/es6.function.name");
+
+require("core-js/modules/es6.array.map");
+
+require("core-js/modules/es7.array.includes");
+
+require("core-js/modules/es6.string.includes");
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -45,9 +47,9 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -67,7 +69,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -100,7 +102,7 @@ var DataRow = /*#__PURE__*/function (_Component) {
           _onMouseUp = _this$props.onMouseUp,
           _onMouseDown = _this$props.onMouseDown,
           _onContextMenu = _this$props.onContextMenu;
-      return _react["default"].createElement("tr", {
+      return /*#__PURE__*/_react["default"].createElement("tr", {
         onClick: function onClick(e) {
           return _onClick(e, row);
         },
@@ -131,9 +133,9 @@ var DataRow = /*#__PURE__*/function (_Component) {
         return;
       }
 
-      var checkbox = _react["default"].createElement("div", {
+      var checkbox = /*#__PURE__*/_react["default"].createElement("div", {
         className: "form-check"
-      }, _react["default"].createElement("input", {
+      }, /*#__PURE__*/_react["default"].createElement("input", {
         name: "bulk-select-".concat(row.id),
         type: "checkbox",
         checked: this.props.checkboxIsChecked(row),
@@ -146,7 +148,7 @@ var DataRow = /*#__PURE__*/function (_Component) {
         disabled: disableCheckbox
       }));
 
-      return _react["default"].createElement("td", null, checkbox);
+      return /*#__PURE__*/_react["default"].createElement("td", null, checkbox);
     }
   }, {
     key: "renderCell",
@@ -165,9 +167,9 @@ var DataRow = /*#__PURE__*/function (_Component) {
         var column = editableColumns[columnIndex];
 
         if (column.type === 'select') {
-          return _react["default"].createElement("td", {
+          return /*#__PURE__*/_react["default"].createElement("td", {
             key: key
-          }, _react["default"].createElement("select", {
+          }, /*#__PURE__*/_react["default"].createElement("select", {
             defaultValue: value,
             value: column.controlled ? value : undefined,
             onChange: function onChange(event) {
@@ -175,15 +177,15 @@ var DataRow = /*#__PURE__*/function (_Component) {
               column.onChange(event, field.name, row, index);
             }
           }, column.optionsForRow(row, field.name).map(function (option) {
-            return _react["default"].createElement("option", {
+            return /*#__PURE__*/_react["default"].createElement("option", {
               value: option.value
             }, option.label);
           })));
         }
 
-        return _react["default"].createElement("td", {
+        return /*#__PURE__*/_react["default"].createElement("td", {
           key: key
-        }, _react["default"].createElement("input", {
+        }, /*#__PURE__*/_react["default"].createElement("input", {
           type: column.type,
           defaultValue: value,
           value: column.controlled ? value : undefined,
@@ -194,14 +196,14 @@ var DataRow = /*#__PURE__*/function (_Component) {
         }));
       }
 
-      if (_react["default"].isValidElement(value)) {
-        return _react["default"].createElement("td", {
+      if ( /*#__PURE__*/_react["default"].isValidElement(value)) {
+        return /*#__PURE__*/_react["default"].createElement("td", {
           key: key
         }, value);
       }
 
       if (this.shouldDangerouslyRenderField(field.name)) {
-        return _react["default"].createElement("td", {
+        return /*#__PURE__*/_react["default"].createElement("td", {
           key: key,
           dangerouslySetInnerHTML: {
             __html: value
@@ -213,7 +215,7 @@ var DataRow = /*#__PURE__*/function (_Component) {
         value = JSON.stringify(value);
       }
 
-      return _react["default"].createElement("td", {
+      return /*#__PURE__*/_react["default"].createElement("td", {
         key: key
       }, value);
     }
@@ -233,33 +235,33 @@ var DataRow = /*#__PURE__*/function (_Component) {
       if (!buttons.length && !actions.length) {
         return null;
       } else if (!buttons.length) {
-        return _react["default"].createElement("td", null);
+        return /*#__PURE__*/_react["default"].createElement("td", null);
       }
 
       var button = buttons[0];
 
       if (buttons.length === 1) {
-        return _react["default"].createElement("td", {
+        return /*#__PURE__*/_react["default"].createElement("td", {
           className: "rddt-action-cell"
         }, this.renderFirstButton(button, row));
       }
 
-      return _react["default"].createElement("td", {
+      return /*#__PURE__*/_react["default"].createElement("td", {
         className: "rddt-action-cell"
-      }, _react["default"].createElement("div", {
+      }, /*#__PURE__*/_react["default"].createElement("div", {
         className: "btn-group",
         onClick: function onClick(e) {
           return e.stopPropagation();
         }
-      }, this.renderFirstButton(button, row), _react["default"].createElement("button", {
+      }, this.renderFirstButton(button, row), /*#__PURE__*/_react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary dropdown-toggle dropdown-toggle-split",
         "data-toggle": "dropdown",
         "aria-haspopup": "true",
         "aria-expanded": "false"
-      }, _react["default"].createElement("span", {
+      }, /*#__PURE__*/_react["default"].createElement("span", {
         className: "sr-only"
-      }, "Toggle Dropdown")), _react["default"].createElement("div", {
+      }, "Toggle Dropdown")), /*#__PURE__*/_react["default"].createElement("div", {
         className: "dropdown-menu",
         "aria-labelledby": "dropdownMenuButton"
       }, buttons.map(function (button, index) {
@@ -273,7 +275,7 @@ var DataRow = /*#__PURE__*/function (_Component) {
         return button.render(row);
       }
 
-      return _react["default"].createElement("button", {
+      return /*#__PURE__*/_react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary",
         onClick: function onClick(e) {
@@ -289,7 +291,7 @@ var DataRow = /*#__PURE__*/function (_Component) {
       }
 
       if (typeof button.render === 'function') {
-        return _react["default"].createElement("div", {
+        return /*#__PURE__*/_react["default"].createElement("div", {
           style: {
             cursor: 'pointer'
           },
@@ -298,7 +300,7 @@ var DataRow = /*#__PURE__*/function (_Component) {
         }, button.render(row));
       }
 
-      return _react["default"].createElement("div", {
+      return /*#__PURE__*/_react["default"].createElement("div", {
         style: {
           cursor: 'pointer'
         },

--- a/dist/Components/Pagination.js
+++ b/dist/Components/Pagination.js
@@ -1,37 +1,37 @@
 "use strict";
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+require("core-js/modules/web.dom.iterable");
 
-require("core-js/modules/es6.reflect.construct.js");
+require("core-js/modules/es6.array.iterator");
 
-require("core-js/modules/es6.object.create.js");
+require("core-js/modules/es6.string.iterator");
 
-require("core-js/modules/es6.object.define-property.js");
-
-require("core-js/modules/es6.weak-map.js");
-
-require("core-js/modules/es6.string.iterator.js");
-
-require("core-js/modules/es6.object.to-string.js");
-
-require("core-js/modules/es6.array.iterator.js");
-
-require("core-js/modules/web.dom.iterable.js");
-
-require("core-js/modules/es6.object.get-own-property-descriptor.js");
-
-require("core-js/modules/es6.symbol.js");
+require("core-js/modules/es6.weak-map");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
 
-require("core-js/modules/es6.array.for-each.js");
+require("core-js/modules/es7.symbol.async-iterator");
 
-require("core-js/modules/es6.object.set-prototype-of.js");
+require("core-js/modules/es6.symbol");
 
-require("core-js/modules/es6.object.get-prototype-of.js");
+require("core-js/modules/es6.object.define-property");
+
+require("core-js/modules/es6.object.create");
+
+require("core-js/modules/es6.regexp.to-string");
+
+require("core-js/modules/es6.date.to-string");
+
+require("core-js/modules/es6.object.to-string");
+
+require("core-js/modules/es6.reflect.construct");
+
+require("core-js/modules/es6.object.set-prototype-of");
+
+require("core-js/modules/es6.array.for-each");
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -39,9 +39,11 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -59,7 +61,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -90,10 +92,10 @@ var Pagination = /*#__PURE__*/function (_Component) {
       }
 
       this.getPagesToDisplay(currentPage, totalPages).forEach(function (page, index) {
-        pageLinks.push(_react["default"].createElement("li", {
+        pageLinks.push( /*#__PURE__*/_react["default"].createElement("li", {
           key: "page_index_".concat(index),
           className: "page-item ".concat(currentPage === page ? 'active' : '')
-        }, _react["default"].createElement("button", {
+        }, /*#__PURE__*/_react["default"].createElement("button", {
           type: "button",
           className: "page-link ".concat(!page ? 'disabled' : ''),
           onClick: function onClick() {
@@ -103,21 +105,21 @@ var Pagination = /*#__PURE__*/function (_Component) {
           }
         }, page || '...')));
       });
-      return _react["default"].createElement("nav", {
+      return /*#__PURE__*/_react["default"].createElement("nav", {
         "aria-label": "Page navigation ml-auto"
-      }, _react["default"].createElement("ul", {
+      }, /*#__PURE__*/_react["default"].createElement("ul", {
         className: "pagination mb-0"
-      }, _react["default"].createElement("li", {
+      }, /*#__PURE__*/_react["default"].createElement("li", {
         className: "page-item ".concat(currentPage <= 1 ? 'disabled' : '')
-      }, _react["default"].createElement("button", {
+      }, /*#__PURE__*/_react["default"].createElement("button", {
         type: "button",
         className: "page-link",
         onClick: function onClick() {
           return _this.previousPage();
         }
-      }, "Previous")), pageLinks, _react["default"].createElement("li", {
+      }, "Previous")), pageLinks, /*#__PURE__*/_react["default"].createElement("li", {
         className: "page-item ".concat(currentPage >= totalPages ? 'disabled' : '')
-      }, _react["default"].createElement("button", {
+      }, /*#__PURE__*/_react["default"].createElement("button", {
         type: "button",
         className: "page-link",
         onClick: function onClick() {

--- a/dist/Components/Pagination.js
+++ b/dist/Components/Pagination.js
@@ -85,8 +85,9 @@ var Pagination = /*#__PURE__*/function (_Component) {
       var props = this.props;
       var currentPage = props.currentPage;
       var totalPages = props.totalPages;
+      var alwaysShowPagination = props.alwaysShowPagination;
 
-      if (totalPages <= 1) {
+      if (!alwaysShowPagination && totalPages <= 1) {
         return null;
       }
 
@@ -174,13 +175,15 @@ var Pagination = /*#__PURE__*/function (_Component) {
 }(_react.Component);
 
 Pagination.defaultProps = {
-  paginationDelta: 4
+  paginationDelta: 4,
+  alwaysShowPagination: false
 };
 Pagination.propTypes = {
   currentPage: _propTypes["default"].number,
   totalPages: _propTypes["default"].number,
   changePage: _propTypes["default"].func,
-  paginationDelta: _propTypes["default"].number
+  paginationDelta: _propTypes["default"].number,
+  alwaysShowPagination: _propTypes["default"].bool
 };
 var _default = Pagination;
 exports["default"] = _default;

--- a/dist/Components/PerPage.js
+++ b/dist/Components/PerPage.js
@@ -1,39 +1,39 @@
 "use strict";
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+require("core-js/modules/web.dom.iterable");
 
-require("core-js/modules/es6.reflect.construct.js");
+require("core-js/modules/es6.array.iterator");
 
-require("core-js/modules/es6.object.create.js");
+require("core-js/modules/es6.string.iterator");
 
-require("core-js/modules/es6.object.define-property.js");
-
-require("core-js/modules/es6.weak-map.js");
-
-require("core-js/modules/es6.string.iterator.js");
-
-require("core-js/modules/es6.object.to-string.js");
-
-require("core-js/modules/es6.array.iterator.js");
-
-require("core-js/modules/web.dom.iterable.js");
-
-require("core-js/modules/es6.object.get-own-property-descriptor.js");
-
-require("core-js/modules/es6.symbol.js");
+require("core-js/modules/es6.weak-map");
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
 
-require("core-js/modules/es6.function.bind.js");
+require("core-js/modules/es7.symbol.async-iterator");
 
-require("core-js/modules/es6.array.map.js");
+require("core-js/modules/es6.symbol");
 
-require("core-js/modules/es6.object.set-prototype-of.js");
+require("core-js/modules/es6.object.define-property");
 
-require("core-js/modules/es6.object.get-prototype-of.js");
+require("core-js/modules/es6.object.create");
+
+require("core-js/modules/es6.regexp.to-string");
+
+require("core-js/modules/es6.date.to-string");
+
+require("core-js/modules/es6.object.to-string");
+
+require("core-js/modules/es6.reflect.construct");
+
+require("core-js/modules/es6.object.set-prototype-of");
+
+require("core-js/modules/es6.array.map");
+
+require("core-js/modules/es6.function.bind");
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -41,9 +41,11 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
-function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -61,7 +63,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -99,20 +101,20 @@ var PerPage = /*#__PURE__*/function (_Component) {
           defaultValue = _this$props.defaultValue,
           options = _this$props.options,
           totalRows = _this$props.totalRows;
-      return _react["default"].createElement("div", {
+      return /*#__PURE__*/_react["default"].createElement("div", {
         className: container
-      }, _react["default"].createElement("span", null, "Showing"), _react["default"].createElement("div", {
+      }, /*#__PURE__*/_react["default"].createElement("span", null, "Showing"), /*#__PURE__*/_react["default"].createElement("div", {
         className: innerContainer
-      }, _react["default"].createElement("select", {
+      }, /*#__PURE__*/_react["default"].createElement("select", {
         className: select,
         value: value || defaultValue,
         onChange: this.onChange
       }, options.map(function (option) {
-        return _react["default"].createElement("option", {
+        return /*#__PURE__*/_react["default"].createElement("option", {
           key: option,
           value: option
         }, option);
-      }))), _react["default"].createElement("span", null, "of ", totalRows, " records"));
+      }))), /*#__PURE__*/_react["default"].createElement("span", null, "of ", totalRows, " records"));
     }
   }]);
 

--- a/dist/DynamicDataTable.js
+++ b/dist/DynamicDataTable.js
@@ -702,7 +702,8 @@ var DynamicDataTable = /*#__PURE__*/function (_Component) {
         changePage: function changePage(page) {
           return props.changePage(page);
         },
-        paginationDelta: props.paginationDelta
+        paginationDelta: props.paginationDelta,
+        alwaysShowPagination: props.alwaysShowPagination
       });
     }
   }, {
@@ -833,7 +834,8 @@ DynamicDataTable.propTypes = {
   onMasterCheckboxChange: _propTypes["default"].func,
   renderMasterCheckbox: _propTypes["default"].bool,
   onCheckboxChange: _propTypes["default"].func,
-  footer: _propTypes["default"].oneOfType([_propTypes["default"].func, _propTypes["default"].node])
+  footer: _propTypes["default"].oneOfType([_propTypes["default"].func, _propTypes["default"].node]),
+  alwaysShowPagination: _propTypes["default"].bool
 };
 DynamicDataTable.defaultProps = {
   rows: [],
@@ -886,7 +888,8 @@ DynamicDataTable.defaultProps = {
   onMasterCheckboxChange: DynamicDataTable.noop,
   renderMasterCheckbox: true,
   onCheckboxChange: DynamicDataTable.noop,
-  footer: null
+  footer: null,
+  alwaysShowPagination: false
 };
 var _default = DynamicDataTable;
 exports["default"] = _default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-require("core-js/modules/es6.object.define-property.js");
+require("core-js/modules/es6.object.define-property");
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.17.2",
+  "version": "7.18.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langleyfoxall/react-dynamic-data-table",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "description": "Re-usable data table for React with sortable columns, pagination and more.",
   "keywords": [
     "react",

--- a/src/Components/Pagination.jsx
+++ b/src/Components/Pagination.jsx
@@ -8,8 +8,9 @@ class Pagination extends Component {
         const props = this.props;
         const currentPage = props.currentPage;
         const totalPages = props.totalPages;
+        const alwaysShowPagination = props.alwaysShowPagination;
 
-        if (totalPages <= 1) {
+        if (!alwaysShowPagination && totalPages <= 1) {
             return null;
         }
 
@@ -85,6 +86,7 @@ class Pagination extends Component {
 
 Pagination.defaultProps = {
     paginationDelta: 4,
+    alwaysShowPagination: false,
 };
 
 Pagination.propTypes = {
@@ -92,6 +94,7 @@ Pagination.propTypes = {
     totalPages: PropTypes.number,
     changePage: PropTypes.func,
     paginationDelta: PropTypes.number,
+    alwaysShowPagination: PropTypes.bool,
 };
 
 export default Pagination;

--- a/src/DynamicDataTable.jsx
+++ b/src/DynamicDataTable.jsx
@@ -618,6 +618,7 @@ class DynamicDataTable extends Component {
                 totalPages={props.totalPages}
                 changePage={(page) => props.changePage(page)}
                 paginationDelta={props.paginationDelta}
+                alwaysShowPagination={props.alwaysShowPagination}
             />
         );
     }
@@ -714,7 +715,8 @@ DynamicDataTable.propTypes = {
     onCheckboxChange: PropTypes.func,
     footer: PropTypes.oneOfType([
         PropTypes.func, PropTypes.node
-    ])
+    ]),
+    alwaysShowPagination: PropTypes.bool
 };
 
 DynamicDataTable.defaultProps = {
@@ -768,7 +770,8 @@ DynamicDataTable.defaultProps = {
     onMasterCheckboxChange: DynamicDataTable.noop,
     renderMasterCheckbox: true,
     onCheckboxChange: DynamicDataTable.noop,
-    footer: null
+    footer: null,
+    alwaysShowPagination: false
 };
 
 export default DynamicDataTable;


### PR DESCRIPTION
This PR adds an `alwaysShowPagination` prop to the `DynamicDataTable` component and the `Pagination` component which, if provided, causes the "Previous", "Next" and "Page 1" button to appear even if there is only one page to show.

As the table is only rendered if there is data, this feature does not need to deal with zero-length datasets, and the default operation is not effected so as not to break anything that already uses this feature.